### PR TITLE
chore: correct last user prompt detection

### DIFF
--- a/anthropic_test.go
+++ b/anthropic_test.go
@@ -1,0 +1,172 @@
+package aibridge_test
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/coder/aibridge"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicLastUserPrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		wrapper     *aibridge.MessageNewParamsWrapper
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "nil struct",
+			expectError: true,
+			errorMsg:    "nil struct",
+		},
+		{
+			name: "no messages",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{},
+				},
+			},
+			expectError: true,
+			errorMsg:    "no messages",
+		},
+		{
+			name: "last message not from user",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("user message"),
+							},
+						},
+						{
+							Role: anthropic.MessageParamRoleAssistant,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("assistant message"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "last user message with empty content",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role:    anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "last user message with single text content",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("Hello, world!"),
+							},
+						},
+					},
+				},
+			},
+			expected: "Hello, world!",
+		},
+		{
+			name: "last user message with multiple content blocks - text at end",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewImageBlockBase64("image/png", "base64data"),
+								anthropic.NewTextBlock("First text"),
+								anthropic.NewImageBlockBase64("image/jpeg", "moredata"),
+								anthropic.NewTextBlock("Last text"),
+							},
+						},
+					},
+				},
+			},
+			expected: "Last text",
+		},
+		{
+			name: "last user message with only non-text content",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewImageBlockBase64("image/png", "base64data"),
+								anthropic.NewImageBlockBase64("image/jpeg", "moredata"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple messages with last being user",
+			wrapper: &aibridge.MessageNewParamsWrapper{
+				MessageNewParams: anthropic.MessageNewParams{
+					Messages: []anthropic.MessageParam{
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("First user message"),
+							},
+						},
+						{
+							Role: anthropic.MessageParamRoleAssistant,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("Assistant response"),
+							},
+						},
+						{
+							Role: anthropic.MessageParamRoleUser,
+							Content: []anthropic.ContentBlockParamUnion{
+								anthropic.NewTextBlock("Second user message"),
+							},
+						},
+					},
+				},
+			},
+			expected: "Second user message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.wrapper.LastUserPrompt()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				// Check pointer equality - both nil or both non-nil
+				if tt.expected == "" {
+					require.Nil(t, result)
+				} else {
+					require.NotNil(t, result)
+					// The result should point to the same string from the content block
+					require.Equal(t, tt.expected, *result)
+				}
+			}
+		})
+	}
+}

--- a/bridge_integration_test.go
+++ b/bridge_integration_test.go
@@ -426,7 +426,7 @@ func TestSimple(t *testing.T) {
 
 					// Then: I expect the prompt to have been tracked.
 					require.NotEmpty(t, recorderClient.userPrompts, "no prompts tracked")
-					assert.Equal(t, "how many angels can dance on the head of a pin", recorderClient.userPrompts[0].Prompt)
+					assert.Contains(t, recorderClient.userPrompts[0].Prompt, "how many angels can dance on the head of a pin")
 
 					// Validate that responses have their IDs overridden with a interception ID rather than the original ID from the upstream provider.
 					// The reason for this is that Bridge may make multiple upstream requests (i.e. to invoke injected tools), and clients will not be expecting

--- a/openai_test.go
+++ b/openai_test.go
@@ -1,0 +1,133 @@
+package aibridge_test
+
+import (
+	"testing"
+
+	"github.com/coder/aibridge"
+	"github.com/openai/openai-go/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAILastUserPrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		wrapper     *aibridge.ChatCompletionNewParamsWrapper
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "nil struct",
+			expectError: true,
+			errorMsg:    "nil struct",
+		},
+		{
+			name: "no messages",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{},
+				},
+			},
+			expectError: true,
+			errorMsg:    "no messages",
+		},
+		{
+			name: "last message not from user",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage("user message"),
+						openai.AssistantMessage("assistant message"),
+					},
+				},
+			},
+		},
+		{
+			name: "user message with string content",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage("Hello, world!"),
+					},
+				},
+			},
+			expected: "Hello, world!",
+		},
+		{
+			name: "user message with empty string",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage(""),
+					},
+				},
+			},
+		},
+		{
+			name: "user message with array content - text at end",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+							openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "https://example.com/image.png",
+							}),
+							openai.TextContentPart("First text"),
+							openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "https://example.com/image2.png",
+							}),
+							openai.TextContentPart("Last text"),
+						}),
+					},
+				},
+			},
+			expected: "Last text",
+		},
+		{
+			name: "user message with array content - no text",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
+							openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+								URL: "https://example.com/image.png",
+							}),
+						}),
+					},
+				},
+			},
+		},
+		{
+			name: "user message with empty array",
+			wrapper: &aibridge.ChatCompletionNewParamsWrapper{
+				ChatCompletionNewParams: openai.ChatCompletionNewParams{
+					Messages: []openai.ChatCompletionMessageParamUnion{
+						openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{}),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.wrapper.LastUserPrompt()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				if tt.expected == "" {
+					require.Nil(t, result)
+				} else {
+					require.NotNil(t, result)
+					require.Equal(t, tt.expected, *result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
We're currently seeing a few prompts being captured incorrectly (or blank), and it was because of faulty logic in the last user prompt detection.