### PR TITLE
chore: correcting openai stream error handling

### DIFF
--- a/intercept_openai_chat_streaming.go
+++ b/intercept_openai_chat_streaming.go
@@ -185,7 +185,7 @@ func (i *OpenAIStreamingChatInterception) ProcessRequest(w http.ResponseWriter, 
 				// We can't reflect an error back if there's a connection error or the request context was canceled.
 			} else if oaiErr := getOpenAIErrorResponse(streamErr); oaiErr != nil {
 				logger.Warn(ctx, "openai stream error", slog.Error(streamErr))
-				interceptionErr = fmt.Errorf("stream error: %w", oaiErr)
+				interceptionErr = oaiErr
 			} else {
 				logger.Warn(ctx, "unknown error", slog.Error(streamErr))
 				// Unfortunately, the OpenAI SDK does not support parsing errors received in the stream


### PR DESCRIPTION
Oversight on my part, I think I stashed some changes and the incomplete impl landed.

In any case, it's working now:

```
 echo 'what is my coder username?' | OPENAI_BASE_URL="http://localhost:3000/api/experimental/aibridge/openai/v1" llm -m gpt-5 -u --key $KEY
Error: POST "https://api.openai.com/v1/chat/completions": 400 Bad Request {
    "message": "Invalid schema for function 'bmcp_coder_coder_workspace_ls': schema must be a JSON Schema of 'type: \"object\"', got 'type: \"None\"'.",
    "type": "invalid_request_error",
    "param": "tools[0].function.parameters",
    "code": "invalid_function_parameters"
  }
```