### PR TITLE
chore: allow `/v1/messages/count_tokens` passthrough

### DIFF
--- a/provider_anthropic.go
+++ b/provider_anthropic.go
@@ -54,6 +54,7 @@ func (p *AnthropicProvider) PassthroughRoutes() []string {
 	return []string{
 		"/v1/models",
 		"/v1/models/", // See https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux.
+		"/v1/messages/count_tokens",
 	}
 }
 


### PR DESCRIPTION
Claude Code called out to https://docs.claude.com/en/api/messages-count-tokens on startup, let's reverse-proxy it.

We could/should probably intercept these requests in future to inject our tools and have those contribute to token count, but for now a simple passthrough is sufficient.