### PR TITLE
chore: set cache control markers on tools

### DIFF
--- a/intercept_anthropic_messages_blocking.go
+++ b/intercept_anthropic_messages_blocking.go
@@ -41,6 +41,7 @@ func (i *AnthropicMessagesBlockingInterception) ProcessRequest(w http.ResponseWr
 
 	ctx := r.Context()
 
+	i.removeUnnecessaryCacheMarkers()
 	i.injectTools()
 
 	var (


### PR DESCRIPTION
Injected tools are not being cached currently, leading to unnecessarily inflated costs.

This PR follows guidance from https://docs.claude.com/en/docs/build-with-claude/prompt-caching#prompt-caching-examples:

> The `cache_control` parameter on the last tool definition caches all tool definitions.