### PR TITLE
feat: add support for max_completion_tokens parameter

### DIFF
--- a/openai.go
+++ b/openai.go
@@ -48,8 +48,8 @@ func (c *ChatCompletionNewParamsWrapper) UnmarshalJSON(raw []byte) error {
 		c.ChatCompletionNewParams.StreamOptions = openai.ChatCompletionStreamOptionsParam{}
 	}
 
-	// Extract max_completion_tokens if present
-	// We need to check if the field exists in the JSON to properly handle explicit 0 values
+	// Extract max_completion_tokens if present and positive
+	// OpenAI API requires positive integers for token limits
 	var data map[string]any
 	if err := json.Unmarshal(raw, &data); err == nil {
 		if val, exists := data["max_completion_tokens"]; exists {
@@ -66,9 +66,12 @@ func (c *ChatCompletionNewParamsWrapper) UnmarshalJSON(raw []byte) error {
 				// Invalid type, skip
 				return nil
 			}
-			c.MaxCompletionTokens = &tokens
-			// Set it in the underlying params as well
-			c.ChatCompletionNewParams.MaxCompletionTokens = openai.Int(int64(tokens))
+			// Only set if positive (0 and negative values are invalid)
+			if tokens > 0 {
+				c.MaxCompletionTokens = &tokens
+				// Set it in the underlying params as well
+				c.ChatCompletionNewParams.MaxCompletionTokens = openai.Int(int64(tokens))
+			}
 		}
 	}
 

--- a/openai_test.go
+++ b/openai_test.go
@@ -150,7 +150,7 @@ func TestMaxCompletionTokens(t *testing.T) {
 		require.Equal(t, 1024, *wrapper.MaxCompletionTokens)
 	})
 
-	t.Run("unmarshal max_completion_tokens with zero value", func(t *testing.T) {
+	t.Run("unmarshal max_completion_tokens with zero value ignored", func(t *testing.T) {
 		jsonStr := `{
 			"model": "gpt-4o",
 			"messages": [{"role": "user", "content": "Hello"}],
@@ -160,8 +160,20 @@ func TestMaxCompletionTokens(t *testing.T) {
 		var wrapper aibridge.ChatCompletionNewParamsWrapper
 		err := json.Unmarshal([]byte(jsonStr), &wrapper)
 		require.NoError(t, err)
-		require.NotNil(t, wrapper.MaxCompletionTokens, "max_completion_tokens should be set even when 0")
-		require.Equal(t, 0, *wrapper.MaxCompletionTokens)
+		require.Nil(t, wrapper.MaxCompletionTokens, "max_completion_tokens should not be set when 0 (invalid value)")
+	})
+
+	t.Run("unmarshal max_completion_tokens with negative value ignored", func(t *testing.T) {
+		jsonStr := `{
+			"model": "gpt-4o",
+			"messages": [{"role": "user", "content": "Hello"}],
+			"max_completion_tokens": -100
+		}`
+
+		var wrapper aibridge.ChatCompletionNewParamsWrapper
+		err := json.Unmarshal([]byte(jsonStr), &wrapper)
+		require.NoError(t, err)
+		require.Nil(t, wrapper.MaxCompletionTokens, "max_completion_tokens should not be set when negative (invalid value)")
 	})
 
 	t.Run("marshal max_completion_tokens to JSON", func(t *testing.T) {
@@ -183,27 +195,6 @@ func TestMaxCompletionTokens(t *testing.T) {
 		err = json.Unmarshal(jsonBytes, &result)
 		require.NoError(t, err)
 		require.Equal(t, float64(2048), result["max_completion_tokens"])
-	})
-
-	t.Run("marshal max_completion_tokens with zero value", func(t *testing.T) {
-		maxTokens := 0
-		wrapper := aibridge.ChatCompletionNewParamsWrapper{
-			ChatCompletionNewParams: openai.ChatCompletionNewParams{
-				Model: openai.ChatModelGPT4o,
-				Messages: []openai.ChatCompletionMessageParamUnion{
-					openai.UserMessage("Hello"),
-				},
-			},
-			MaxCompletionTokens: &maxTokens,
-		}
-
-		jsonBytes, err := json.Marshal(wrapper)
-		require.NoError(t, err)
-
-		var result map[string]interface{}
-		err = json.Unmarshal(jsonBytes, &result)
-		require.NoError(t, err)
-		require.Equal(t, float64(0), result["max_completion_tokens"], "max_completion_tokens should be present even when 0")
 	})
 
 	t.Run("max_completion_tokens not set when nil", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds support for the `max_completion_tokens` parameter required by newer OpenAI models (gpt-5, gpt-4o) instead of `max_tokens`.

## Changes

- Added `MaxCompletionTokens` field to `ChatCompletionNewParamsWrapper`
- Updated `MarshalJSON` to include `max_completion_tokens` in extras map when set
- Updated `UnmarshalJSON` to extract and set `max_completion_tokens` from incoming JSON
- Added comprehensive test coverage for the new parameter including:
  - Unmarshaling from JSON
  - Marshaling to JSON
  - Ensuring parameter is not present when nil

## Test Plan

- [x] All existing tests pass
- [x] New test `TestMaxCompletionTokens` verifies:
  - Parameter is correctly unmarshaled from JSON
  - Parameter is correctly marshaled to JSON
  - Parameter is not included when nil
- [x] Code formatted with `make fmt`

## Related Issues

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)