### PR TITLE
chore: add apiKeyId to context actor

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,10 +10,13 @@ type ToolArgs any
 type Metadata map[string]any
 
 type InterceptionRecord struct {
-	ID                           string
-	InitiatorID, Provider, Model string
-	Metadata                     Metadata
-	StartedAt                    time.Time
+	ID          string
+	APIKeyID    string
+	InitiatorID string
+	Provider    string
+	Model       string
+	Metadata    Metadata
+	StartedAt   time.Time
 }
 
 type InterceptionRecordEnded struct {

--- a/context.go
+++ b/context.go
@@ -1,16 +1,19 @@
 package aibridge
 
-import "context"
+import (
+	"context"
+)
 
 type actorContextKey struct{}
 
 type actor struct {
+	apiKeyID string
 	id       string
 	metadata Metadata
 }
 
-func AsActor(ctx context.Context, actorID string, metadata Metadata) context.Context {
-	return context.WithValue(ctx, actorContextKey{}, &actor{id: actorID, metadata: metadata})
+func AsActor(ctx context.Context, apiKeyID string, actorID string, metadata Metadata) context.Context {
+	return context.WithValue(ctx, actorContextKey{}, &actor{apiKeyID: apiKeyID, id: actorID, metadata: metadata})
 }
 
 func actorFromContext(ctx context.Context) *actor {

--- a/interception.go
+++ b/interception.go
@@ -54,6 +54,7 @@ func newInterceptionProcessor(p Provider, logger slog.Logger, recorder Recorder,
 
 		if err := recorder.RecordInterception(r.Context(), &InterceptionRecord{
 			ID:          interceptor.ID().String(),
+			APIKeyID:    actor.apiKeyID,
 			Metadata:    actor.metadata,
 			InitiatorID: actor.id,
 			Provider:    p.Name(),


### PR DESCRIPTION
Adds `apiKeyID` field to actor in context.
Used in https://github.com/coder/coder/pull/20513
Needed for tracking API key usage with bridge (https://github.com/coder/coder/issues/20001).