### PR TITLE
feat: add support for ANTHROPIC_CUSTOM_HEADERS environment variable

### DIFF
--- a/bridge_integration_test.go
+++ b/bridge_integration_test.go
@@ -499,7 +499,7 @@ func TestSimple(t *testing.T) {
 			fixture: oaiSimple,
 			configureFunc: func(addr string, client aibridge.Recorder) (*aibridge.RequestBridge, error) {
 				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
-				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(aibridge.OpenAIConfig(anthropicCfg(addr, apiKey)))}, logger, client, mcp.NewServerProxyManager(nil))
+				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(openaiCfg(addr, apiKey))}, logger, client, mcp.NewServerProxyManager(nil))
 			},
 			getResponseIDFunc: func(streaming bool, resp *http.Response) (string, error) {
 				if streaming {
@@ -650,7 +650,7 @@ func TestFallthrough(t *testing.T) {
 			fixture: oaiFallthrough,
 			configureFunc: func(addr string, client aibridge.Recorder) (aibridge.Provider, *aibridge.RequestBridge) {
 				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
-				provider := aibridge.NewOpenAIProvider(aibridge.OpenAIConfig(anthropicCfg(addr, apiKey)))
+				provider := aibridge.NewOpenAIProvider(openaiCfg(addr, apiKey))
 				bridge, err := aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{provider}, logger, client, mcp.NewServerProxyManager(nil))
 				require.NoError(t, err)
 				return provider, bridge
@@ -838,7 +838,7 @@ func TestOpenAIInjectedTools(t *testing.T) {
 
 			configureFn := func(addr string, client aibridge.Recorder, srvProxyMgr *mcp.ServerProxyManager) (*aibridge.RequestBridge, error) {
 				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
-				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(aibridge.OpenAIConfig(anthropicCfg(addr, apiKey)))}, logger, client, srvProxyMgr)
+				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(openaiCfg(addr, apiKey))}, logger, client, srvProxyMgr)
 			}
 
 			// Build the requirements & make the assertions which are common to all providers.
@@ -1047,7 +1047,7 @@ func TestErrorHandling(t *testing.T) {
 			createRequestFunc: createOpenAIChatCompletionsReq,
 			configureFunc: func(addr string, client aibridge.Recorder, srvProxyMgr *mcp.ServerProxyManager) (*aibridge.RequestBridge, error) {
 				logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
-				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(aibridge.OpenAIConfig(anthropicCfg(addr, apiKey)))}, logger, client, srvProxyMgr)
+				return aibridge.NewRequestBridge(t.Context(), []aibridge.Provider{aibridge.NewOpenAIProvider(openaiCfg(addr, apiKey))}, logger, client, srvProxyMgr)
 			},
 			responseHandlerFn: func(streaming bool, resp *http.Response) {
 				if streaming {
@@ -1359,7 +1359,9 @@ func openaiCfg(url, key string) aibridge.OpenAIConfig {
 
 func anthropicCfg(url, key string) aibridge.AnthropicConfig {
 	return aibridge.AnthropicConfig{
-		BaseURL: url,
-		Key:     key,
+		ProviderConfig: aibridge.ProviderConfig{
+			BaseURL: url,
+			Key:     key,
+		},
 	}
 }

--- a/config.go
+++ b/config.go
@@ -4,10 +4,12 @@ type ProviderConfig struct {
 	BaseURL, Key string
 }
 
-type (
-	OpenAIConfig    ProviderConfig
-	AnthropicConfig ProviderConfig
-)
+type OpenAIConfig ProviderConfig
+
+type AnthropicConfig struct {
+	ProviderConfig
+	CustomHeaders map[string]string
+}
 
 type AWSBedrockConfig struct {
 	Region                     string

--- a/intercept_anthropic_messages_base.go
+++ b/intercept_anthropic_messages_base.go
@@ -99,6 +99,11 @@ func (i *AnthropicMessagesInterceptionBase) newAnthropicClient(ctx context.Conte
 	opts = append(opts, option.WithAPIKey(i.cfg.Key))
 	opts = append(opts, option.WithBaseURL(i.cfg.BaseURL))
 
+	// Inject custom headers if configured
+	for key, value := range i.cfg.CustomHeaders {
+		opts = append(opts, option.WithHeader(key, value))
+	}
+
 	if i.bedrockCfg != nil {
 		ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 		defer cancel()


### PR DESCRIPTION
## Overview
This PR adds support for the `ANTHROPIC_CUSTOM_HEADERS` environment variable, allowing users to inject custom HTTP headers into all Anthropic API requests.

## Changes
- **Configuration**: Added `CustomHeaders` field to `AnthropicConfig`
- **Parsing**: Implemented `parseCustomHeaders()` to parse the environment variable
  - Format: `Name: Value` with multiple headers separated by newlines
  - Handles edge cases: URLs with colons, whitespace, empty lines, malformed headers
- **Injection**: Modified `newAnthropicClient()` to inject headers using `option.WithHeader()`
- **Tests**: Added 15 comprehensive test cases
  - `TestParseCustomHeaders`: 12 test cases for parsing logic
  - `TestCustomHeadersIntegration`: 3 test cases for API integration
- **Compatibility**: Fixed test helpers for new config structure

## Usage Example
```bash
# Single header
export ANTHROPIC_CUSTOM_HEADERS="X-Custom-Header: my-value"

# Multiple headers
export ANTHROPIC_CUSTOM_HEADERS="X-Header-1: value1
X-Header-2: value2"

# Headers with complex values (URLs, etc.)
export ANTHROPIC_CUSTOM_HEADERS="X-Callback-URL: https://example.com:8080/webhook"
```

## Testing
✅ All tests pass (1.486s)
✅ Race detection passes (2.463s)
✅ No linting issues introduced
✅ Code formatted with gofumpt

## Files Modified
- `config.go` - Added CustomHeaders field
- `provider_anthropic.go` - Header parsing and initialization
- `intercept_anthropic_messages_base.go` - Header injection
- `anthropic_internal_test.go` - Comprehensive tests
- `bridge_integration_test.go` - Test helper fixes

**Total**: 285 lines added across 5 files