### PR TITLE
fix: change anthropic streaming marshaling

### DIFF
--- a/bridge_integration_test.go
+++ b/bridge_integration_test.go
@@ -605,7 +605,7 @@ func TestSimple(t *testing.T) {
 					// multiple messages in response to a single request.
 					id, err := tc.getResponseIDFunc(streaming, resp)
 					require.NoError(t, err, "failed to retrieve response ID")
-					require.Nil(t, uuid.Validate(id), "id is not a UUID")
+					require.Nilf(t, uuid.Validate(id), "%s is not a valid UUID", id)
 
 					require.GreaterOrEqual(t, len(recorderClient.tokenUsages), 1)
 					require.Equal(t, recorderClient.tokenUsages[0].MsgID, tc.expectedMsgID)

--- a/intercept_anthropic_messages_streaming.go
+++ b/intercept_anthropic_messages_streaming.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coder/aibridge/mcp"
 	"github.com/google/uuid"
 	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/tidwall/sjson"
 
 	"cdr.dev/slog"
 )
@@ -390,8 +391,7 @@ newStream:
 			}
 
 			// Overwrite response identifier since proxy obscures injected tool call invocations.
-			event.Message.ID = i.ID().String()
-			payload, err := i.marshal(event)
+			payload, err := i.marshalEvent(event)
 			if err != nil {
 				logger.Warn(ctx, "failed to marshal event", slog.Error(err), slog.F("event", event.RawJSON()))
 				lastErr = fmt.Errorf("marshal event: %w", err)
@@ -472,6 +472,20 @@ newStream:
 	}
 
 	return interceptionErr
+}
+
+func (s *AnthropicMessagesStreamingInterception) marshalEvent(event anthropic.MessageStreamEventUnion) ([]byte, error) {
+	sj, err := sjson.Set(event.RawJSON(), "message.id", s.ID().String())
+	if err != nil {
+		return nil, fmt.Errorf("marshal event id failed: %w", err)
+	}
+
+	sj, err = sjson.Set(sj, "usage.output_tokens", event.Usage.OutputTokens)
+	if err != nil {
+		return nil, fmt.Errorf("marshal event usage failed: %w", err)
+	}
+
+	return s.encodeForStream([]byte(sj), event.Type), nil
 }
 
 func (s *AnthropicMessagesStreamingInterception) marshal(payload any) ([]byte, error) {


### PR DESCRIPTION
We need to augment Anthropic's streaming responses to include things like our interception ID, cumulative token usage, etc.

When we stream the intercepted events to the client, we currently marshal them using the [SDK](https://github.com/anthropics/anthropic-sdk-go)'s marshaler, which **does not omit zero-values**.

We ran into an issue with this today in Mux where the [SDK](https://ai-sdk.dev/) they're using does not handle zero-values elegantly:

```
2:40.449PM dist/node/services/workspaceTitleGenerator.js:38 Failed to generate workspace name with AI APICallError [AI_APICallError]: Invalid JSON response
    at /tmp/mux/npm/node_modules/@ai-sdk/provider-utils/dist/index.js:1098:11
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async postToApi (/tmp/mux/npm/node_modules/@ai-sdk/provider-utils/dist/index.js:890:14)
    ... 3 lines matching cause stack trace ...
    at async _retryWithExponentialBackoff (/tmp/mux/npm/node_modules/ai/dist/index.js:1795:12)
    at async fn (/tmp/mux/npm/node_modules/ai/dist/index.js:7086:32)
    at async /tmp/mux/npm/node_modules/ai/dist/index.js:1644:22
    at async generateObject (/tmp/mux/npm/node_modules/ai/dist/index.js:7045:12) {
  cause: _TypeValidationError [AI_TypeValidationError]: Type validation failed: Value: {"id":"5f189cd1-0236-4c5a-a76a-b33af33110b8","content":[{"citations":null,"text":"Based on the issue about the `vscode-web` module not applying settings.json and taking a long time to install, here's a git-safe branch name:","type":"text","signature":"","thinking":"","data":"","id":"","input":null,"name":"","content":{"OfWebSearchResultBlockArray":null,"error_code":"","type":"web_search_tool_result_error"},"tool_use_id":""},{"citations":null,"text":"","type":"tool_use","signature":"","thinking":"","data":"","id":"toolu_0111SMMH1XaxMs2WpJouLu7L","input":{"name":"fix-vscode-web-settings"},"name":"json","content":{"OfWebSearchResultBlockArray":null,"error_code":"","type":"web_search_tool_result_error"},"tool_use_id":""}],"model":"claude-sonnet-4-5-20250929","role":"assistant","stop_reason":"tool_use","stop_sequence":"","type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":19098},"cache_creation_input_tokens":19098,"cache_read_input_tokens":19098,"input_tokens":1804,"output_tokens":205,"server_tool_use":{"web_search_requests":0},"service_tier":""}}.
  Error message: [
    {
      "expected": "array",
      "code": "invalid_type",
      "path": [
        "content",
        0,
        "citations"
      ],
      "message": "Invalid input: expected array, received null"
    }
  ]
```

This PR removes the need for this marshaling, and brings the Anthropic implementation in line with the OpenAI implementation, which had to change this for a [similar reason](https://github.com/coder/aibridge/pull/35).