### PR TITLE
feat: add aibtest package for testing utilities

### DIFF
--- a/metrics_integration_test.go
+++ b/metrics_integration_test.go
@@ -237,8 +237,8 @@ func TestMetrics_InjectedToolUseCount(t *testing.T) {
 	provider := aibridge.NewAnthropicProvider(anthropicCfg(mockAPI.URL, apiKey), nil)
 
 	// Setup mocked MCP server & tools.
-	mcpProxiers, _ := setupMCPServerProxiesForTest(t, testTracer)
-	mcpMgr := mcp.NewServerProxyManager(mcpProxiers, testTracer)
+	mcpMock := newMockMCPServer(t, testTracer)
+	mcpMgr := mcp.NewServerProxyManager(mcpMock.Proxies, testTracer)
 	require.NoError(t, mcpMgr.Init(ctx))
 
 	bridge, err := aibridge.NewRequestBridge(ctx, []aibridge.Provider{provider}, recorder, mcpMgr, logger, metrics, testTracer)

--- a/trace_integration_test.go
+++ b/trace_integration_test.go
@@ -346,7 +346,7 @@ func TestAnthropicInjectedToolsTrace(t *testing.T) {
 			}
 
 			// Build the requirements & make the assertions which are common to all providers.
-			recorderClient, _, proxies, resp := setupInjectedToolTest(t, antSingleInjectedTool, tc.streaming, configureFn, reqFunc)
+			recorderClient, mcpMock, resp := setupInjectedToolTest(t, antSingleInjectedTool, tc.streaming, configureFn, reqFunc)
 
 			defer resp.Body.Close()
 
@@ -358,7 +358,7 @@ func TestAnthropicInjectedToolsTrace(t *testing.T) {
 				model = "beddel"
 			}
 
-			for _, proxy := range proxies {
+			for _, proxy := range mcpMock.Proxies {
 				require.NotEmpty(t, proxy.ListTools())
 				tool := proxy.ListTools()[0]
 
@@ -607,14 +607,14 @@ func TestOpenAIInjectedToolsTrace(t *testing.T) {
 			}
 
 			// Build the requirements & make the assertions which are common to all providers.
-			recorderClient, _, proxies, resp := setupInjectedToolTest(t, oaiSingleInjectedTool, streaming, configureFn, reqFunc)
+			recorderClient, mcpMock, resp := setupInjectedToolTest(t, oaiSingleInjectedTool, streaming, configureFn, reqFunc)
 
 			defer resp.Body.Close()
 
 			require.Len(t, recorderClient.interceptions, 1)
 			intcID := recorderClient.interceptions[0].ID
 
-			for _, proxy := range proxies {
+			for _, proxy := range mcpMock.Proxies {
 				require.NotEmpty(t, proxy.ListTools())
 				tool := proxy.ListTools()[0]
 
@@ -687,7 +687,7 @@ func TestNewServerProxyManagerTraces(t *testing.T) {
 	defer func() { _ = tp.Shutdown(t.Context()) }()
 
 	serverName := "serverName"
-	srv, _ := createMockMCPSrv(t)
+	srv := createMockMCPSrvHandler(t)
 	mcpSrv := httptest.NewServer(srv)
 	t.Cleanup(mcpSrv.Close)
 


### PR DESCRIPTION
## Summary

This PR creates a proper testing package to address the tech debt identified in #73. The package consolidates scattered test helpers and provides well-structured components that reduce boilerplate and improve test readability.

## New Components

### MockUpstreamServer
Simulates LLM provider API responses using txtar fixtures. Features:
- Automatic streaming/non-streaming response handling
- Response mutation for multi-turn conversations
- Custom status code support
- Call counting

### MockMCPServer
Provides a mock MCP server with **integrated call tracking**. This addresses the `callAccumulator` issue mentioned in #73:
- Combines server, HTTP endpoint, and call accumulator into a single struct
- `GetToolCalls(toolName)` returns all recorded invocations
- `TotalCallCount()` returns total invocations across all tools
- `NewMCPManager()` creates an initialized ServerProxyManager ready to use

### MockRecorder
Implements `aibridge.Recorder` for testing with convenient accessors:
- `Interceptions()`, `TokenUsages()`, `ToolUsages()`, `PromptUsages()`
- `TotalInputTokens()`, `TotalOutputTokens()`
- `VerifyAllInterceptionsEnded(t)` for validation

### TestBridge
The main orchestrator that combines everything:
- Creates bridge, HTTP server, recorder, and optional MCP server
- `DoAnthropicRequest(t, reqBody)` and `DoOpenAIRequest(t, reqBody)` methods
- Automatic cleanup on test completion

## Example Usage

Before (from bridge_integration_test.go):
```go
// Manual txtar parsing
arc := txtar.Parse(fixture)
files := filesMap(arc)
reqBody := files[fixtureRequest]

// Manual server setup
ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
srv := newMockServer(ctx, t, files, nil)
t.Cleanup(srv.Close)

// Manual recorder setup
recorderClient := &mockRecorderClient{}

// Manual MCP setup with separate callAccumulator
mcpProxiers, acc := setupMCPServerProxiesForTest(t, testTracer)
mcpMgr := mcp.NewServerProxyManager(mcpProxiers, testTracer)
require.NoError(t, mcpMgr.Init(ctx))

// Manual bridge setup
logger := slogtest.Make(t, &slogtest.Options{}).Leveled(slog.LevelDebug)
providers := []aibridge.Provider{aibridge.NewAnthropicProvider(cfg, nil)}
b, err := aibridge.NewRequestBridge(ctx, providers, recorderClient, mcpMgr, logger, nil, testTracer)

// Manual HTTP server setup
mockSrv := httptest.NewUnstartedServer(b)
mockSrv.Config.BaseContext = func(_ net.Listener) context.Context {
    return aibridge.AsActor(ctx, userID, nil)
}
mockSrv.Start()
t.Cleanup(mockSrv.Close)

// Make request
req := createAnthropicMessagesReq(t, mockSrv.URL, reqBody)
resp, err := client.Do(req)

// Verify tool calls via separate accumulator
invocations := acc.getCallsByTool(mockToolName)
```

After (with aibtest):
```go
// 1. Create mock upstream
upstream := aibtest.NewMockUpstreamServer(t, ctx, fixture)

// 2. Create MCP server with integrated call tracking
mcpServer := aibtest.NewMockMCPServer(t, aibtest.TestTracer())

// 3. Create test bridge (combines everything)
bridge := aibtest.NewTestBridge(t, ctx, aibtest.TestBridgeOptions{
    Provider:  aibridge.NewAnthropicProvider(aibtest.AnthropicConfig(upstream.URL, aibtest.DefaultAPIKey), nil),
    MCPServer: mcpServer,
})

// 4. Make request
resp := bridge.DoAnthropicRequest(t, upstream.Files()[aibtest.FixtureRequest])

// 5. Verify - tool calls are tracked in mcpServer directly
calls := mcpServer.GetToolCalls("my_tool")
bridge.Recorder.VerifyAllInterceptionsEnded(t)
```

## Issues Addressed from #73

- ✅ `callAccumulator` is now integrated into MockMCPServer
- ✅ `setupMCPServerProxiesForTest` return values are consolidated  
- ✅ `proxies` return value complexity is eliminated
- ✅ Common test patterns are abstracted into TestBridge
- ✅ Package can be used externally (e.g., in coder/coder integration tests)

## Testing

All existing tests continue to pass:
```
ok      github.com/coder/aibridge       0.186s
ok      github.com/coder/aibridge/aibtest       1.346s
ok      github.com/coder/aibridge/buildinfo     0.004s
ok      github.com/coder/aibridge/mcp   0.008s
ok      github.com/coder/aibridge/utils 0.004s
```

Resolves #73