### PR TITLE
fix: add thread-safe accessor methods to mockRecorderClient

### DIFF
--- a/bridge_integration_test.go
+++ b/bridge_integration_test.go
@@ -1838,6 +1838,9 @@ func (m *mockRecorderClient) RecordToolUsage(ctx context.Context, req *aibridge.
 }
 
 // RecordedTokenUsages returns a copy of recorded token usages in a thread-safe manner.
+// Note: This is a shallow clone - the slice is copied but the pointers reference the
+// same underlying records. This is sufficient for our test assertions which only read
+// the data and don't modify the records.
 func (m *mockRecorderClient) RecordedTokenUsages() []*aibridge.TokenUsageRecord {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1845,6 +1848,7 @@ func (m *mockRecorderClient) RecordedTokenUsages() []*aibridge.TokenUsageRecord 
 }
 
 // RecordedPromptUsages returns a copy of recorded prompt usages in a thread-safe manner.
+// Note: This is a shallow clone (see RecordedTokenUsages for details).
 func (m *mockRecorderClient) RecordedPromptUsages() []*aibridge.PromptUsageRecord {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1852,6 +1856,7 @@ func (m *mockRecorderClient) RecordedPromptUsages() []*aibridge.PromptUsageRecor
 }
 
 // RecordedToolUsages returns a copy of recorded tool usages in a thread-safe manner.
+// Note: This is a shallow clone (see RecordedTokenUsages for details).
 func (m *mockRecorderClient) RecordedToolUsages() []*aibridge.ToolUsageRecord {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1859,6 +1864,7 @@ func (m *mockRecorderClient) RecordedToolUsages() []*aibridge.ToolUsageRecord {
 }
 
 // RecordedInterceptions returns a copy of recorded interceptions in a thread-safe manner.
+// Note: This is a shallow clone (see RecordedTokenUsages for details).
 func (m *mockRecorderClient) RecordedInterceptions() []*aibridge.InterceptionRecord {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Fixes #59

Fixes data race in `bridge_integration_test.go` where test code was directly accessing `mockRecorderClient` fields (`tokenUsages`, `userPrompts`, `toolUsages`, `interceptions`) without holding the mutex, while the `Record*` methods were modifying these fields under the mutex.

## Changes

Added four new accessor methods that return copies of the recorded data under mutex protection:
- `RecordedTokenUsages()`
- `RecordedPromptUsages()`
- `RecordedToolUsages()`
- `RecordedInterceptions()`

All direct field accesses in tests have been replaced with calls to these new thread-safe accessor methods.

## Testing

All tests pass with `-race` flag enabled:
```
go test -race ./...
ok  	github.com/coder/aibridge	1.335s
ok  	github.com/coder/aibridge/buildinfo	1.014s
ok  	github.com/coder/aibridge/mcp	1.037s
ok  	github.com/coder/aibridge/utils	1.016s
```

## Non-agent testing

```
while true; do go test -timeout 600s -run ^TestAnthropicInjectedTools$ github.com/coder/aibridge -count=500 -race -parallel=8; done
```