### PR TITLE
feat: preserve cache control breakpoints when injecting tools

### DIFF
--- a/mcp/api.go
+++ b/mcp/api.go
@@ -15,7 +15,7 @@ type ServerProxier interface {
 	// See https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management.
 	Shutdown(ctx context.Context) error
 
-	// ListTools lists all known tools.
+	// ListTools lists all known tools. These MUST be sorted in a stable order.
 	ListTools() []*Tool
 	// GetTool returns a given tool, if known, or returns nil.
 	GetTool(id string) *Tool


### PR DESCRIPTION
Closes https://github.com/coder/aibridge/issues/69

When MCP tools are injected into a request that already has tools with
cache control breakpoints, we need to move the breakpoint to the final
tool in the list. This ensures prompt caching continues to work
correctly as documented by Anthropic.

The implementation:

- Captures the first cache control breakpoint found on existing tools
- Clears it from its original location
- Sets it on the final tool after injection