### PR TITLE
testutil: export harness + refactor integration tests

### DIFF
--- a/bridge_integration_injected_tools_test.go
+++ b/bridge_integration_injected_tools_test.go
@@ -1,0 +1,258 @@
+package aibridge_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"cdr.dev/slog"
+	"cdr.dev/slog/sloggers/slogtest"
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
+	"github.com/coder/aibridge"
+	"github.com/coder/aibridge/mcp"
+	"github.com/coder/aibridge/testutil"
+	"github.com/openai/openai-go/v2"
+	oaissestream "github.com/openai/openai-go/v2/packages/ssestream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type injectedToolHarness struct {
+	Recorder    *testutil.RecorderSpy
+	MCP         *testutil.MCPServer
+	MCPProxiers map[string]mcp.ServerProxier
+	Upstream    *testutil.UpstreamServer
+	Bridge      *testutil.BridgeServer
+	Inspector   *testutil.Inspector
+	Response    *http.Response
+
+	RequestBody []byte
+	RequestPath string
+}
+
+func runInjectedToolTest(t *testing.T, providerName string, fixture []byte, streaming bool, tracer trace.Tracer, makeProviders func(upstreamURL string) []aibridge.Provider) injectedToolHarness {
+	t.Helper()
+
+	if tracer == nil {
+		tracer = testTracer
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
+
+	// Fixture-driven upstream.
+	arc := testutil.MustParseTXTAR(t, fixture)
+	llm := testutil.MustLLMFixture(t, arc)
+	upstream := testutil.NewUpstreamServer(t, ctx, llm)
+
+	// MCP server + proxies.
+	mcpSrv := testutil.NewMCPServer(t, testutil.DefaultCoderToolNames())
+	mcpProxiers := mcpSrv.Proxiers(t, "coder", logger, tracer)
+
+	recorder := &testutil.RecorderSpy{}
+	bridge := testutil.NewBridgeServer(t, testutil.BridgeConfig{
+		Ctx:         ctx,
+		ActorID:     userID,
+		Providers:   makeProviders(upstream.URL),
+		Recorder:    recorder,
+		MCPProxiers: mcpProxiers,
+		Logger:      logger,
+		Tracer:      tracer,
+	})
+
+	reqBody := llm.MustRequestBody(t, streaming)
+	req := bridge.NewProviderRequest(t, providerName, reqBody)
+
+	resp, err := bridge.Client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	// Injected tool tests must always produce exactly 2 upstream calls.
+	upstream.RequireCallCountEventually(t, 2)
+
+	inspector := testutil.NewInspector(recorder, mcpSrv, upstream)
+
+	return injectedToolHarness{
+		Recorder:    recorder,
+		MCP:         mcpSrv,
+		MCPProxiers: mcpProxiers,
+		Upstream:    upstream,
+		Bridge:      bridge,
+		Inspector:   inspector,
+		Response:    resp,
+
+		RequestBody: reqBody,
+		RequestPath: req.URL.Path,
+	}
+}
+
+func TestAnthropicInjectedTools(t *testing.T) {
+	t.Parallel()
+
+	for _, streaming := range []bool{true, false} {
+		t.Run(fmt.Sprintf("streaming=%v", streaming), func(t *testing.T) {
+			t.Parallel()
+
+			h := runInjectedToolTest(t, aibridge.ProviderAnthropic, antSingleInjectedTool, streaming, testTracer, func(upstreamURL string) []aibridge.Provider {
+				return []aibridge.Provider{aibridge.NewAnthropicProvider(anthropicCfg(upstreamURL, apiKey), nil)}
+			})
+			resp := h.Response
+
+			// Ensure expected tool was invoked with expected input.
+			h.Inspector.RequireToolCalledOnceWithArgs(t, testutil.ToolCoderListWorkspaces, map[string]any{"owner": "admin"})
+
+			var (
+				content *anthropic.ContentBlockUnion
+				message anthropic.Message
+			)
+			if streaming {
+				// Parse the response stream.
+				decoder := ssestream.NewDecoder(resp)
+				stream := ssestream.NewStream[anthropic.MessageStreamEventUnion](decoder, nil)
+				for stream.Next() {
+					event := stream.Current()
+					require.NoError(t, message.Accumulate(event), "accumulate event")
+				}
+
+				require.NoError(t, stream.Err(), "stream error")
+				require.Len(t, message.Content, 2)
+
+				content = &message.Content[1]
+			} else {
+				// Parse & unmarshal the response.
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err, "read response body")
+
+				require.NoError(t, json.Unmarshal(body, &message), "unmarshal response")
+				require.GreaterOrEqual(t, len(message.Content), 1)
+
+				content = &message.Content[0]
+			}
+
+			// Ensure tool returned expected value.
+			require.NotNil(t, content)
+			require.Contains(t, content.Text, "dd711d5c-83c6-4c08-a0af-b73055906e8c") // The ID of the workspace to be returned.
+
+			// Check the token usage from the client's perspective.
+			//
+			// We overwrite the final message_delta which is relayed to the client to include the
+			// accumulated tokens but currently the SDK only supports accumulating output tokens
+			// for message_delta events.
+			//
+			// For non-streaming requests the token usage is also overwritten and should be faithfully
+			// represented in the response.
+			//
+			// See https://github.com/anthropics/anthropic-sdk-go/blob/v1.12.0/message.go#L2619-L2622
+			if !streaming {
+				assert.EqualValues(t, 15308, message.Usage.InputTokens)
+			}
+			assert.EqualValues(t, 204, message.Usage.OutputTokens)
+
+			// Ensure tokens used during injected tool invocation are accounted for.
+			tokenUsages := h.Recorder.RecordedTokenUsages()
+			assert.EqualValues(t, 15308, testutil.TotalInputTokens(tokenUsages))
+			assert.EqualValues(t, 204, testutil.TotalOutputTokens(tokenUsages))
+
+			// Ensure we received exactly one prompt.
+			promptUsages := h.Recorder.RecordedPromptUsages()
+			require.Len(t, promptUsages, 1)
+		})
+	}
+}
+
+func TestOpenAIInjectedTools(t *testing.T) {
+	t.Parallel()
+
+	for _, streaming := range []bool{true, false} {
+		t.Run(fmt.Sprintf("streaming=%v", streaming), func(t *testing.T) {
+			t.Parallel()
+
+			h := runInjectedToolTest(t, aibridge.ProviderOpenAI, oaiSingleInjectedTool, streaming, testTracer, func(upstreamURL string) []aibridge.Provider {
+				return []aibridge.Provider{aibridge.NewOpenAIProvider(openaiCfg(upstreamURL, apiKey))}
+			})
+			resp := h.Response
+
+			// Ensure expected tool was invoked with expected input.
+			h.Inspector.RequireToolCalledOnceWithArgs(t, testutil.ToolCoderListWorkspaces, map[string]any{"owner": "admin"})
+
+			var (
+				content *openai.ChatCompletionChoice
+				message openai.ChatCompletion
+			)
+			if streaming {
+				// Parse the response stream.
+				decoder := oaissestream.NewDecoder(resp)
+				stream := oaissestream.NewStream[openai.ChatCompletionChunk](decoder, nil)
+				var acc openai.ChatCompletionAccumulator
+				detectedToolCalls := make(map[string]struct{})
+				for stream.Next() {
+					chunk := stream.Current()
+					acc.AddChunk(chunk)
+
+					if len(chunk.Choices) == 0 {
+						continue
+					}
+
+					for _, c := range chunk.Choices {
+						if len(c.Delta.ToolCalls) == 0 {
+							continue
+						}
+
+						for _, t := range c.Delta.ToolCalls {
+							if t.Function.Name == "" {
+								continue
+							}
+
+							detectedToolCalls[t.Function.Name] = struct{}{}
+						}
+					}
+				}
+
+				// Verify that no injected tool call events (or partials thereof) were sent to the client.
+				require.Len(t, detectedToolCalls, 0)
+
+				message = acc.ChatCompletion
+				require.NoError(t, stream.Err(), "stream error")
+			} else {
+				// Parse & unmarshal the response.
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err, "read response body")
+				require.NoError(t, json.Unmarshal(body, &message), "unmarshal response")
+
+				// Verify that no injected tools were sent to the client.
+				require.GreaterOrEqual(t, len(message.Choices), 1)
+				require.Len(t, message.Choices[0].Message.ToolCalls, 0)
+			}
+
+			require.GreaterOrEqual(t, len(message.Choices), 1)
+			content = &message.Choices[0]
+
+			// Ensure tool returned expected value.
+			require.NotNil(t, content)
+			require.Contains(t, content.Message.Content, "dd711d5c-83c6-4c08-a0af-b73055906e8c") // The ID of the workspace to be returned.
+
+			// Check the token usage from the client's perspective.
+			// This *should* work but the openai SDK doesn't accumulate the prompt token details :(.
+			// See https://github.com/openai/openai-go/blob/v2.7.0/streamaccumulator.go#L145-L147.
+			// assert.EqualValues(t, 5047, message.Usage.PromptTokens-message.Usage.PromptTokensDetails.CachedTokens)
+			assert.EqualValues(t, 105, message.Usage.CompletionTokens)
+
+			// Ensure tokens used during injected tool invocation are accounted for.
+			tokenUsages := h.Recorder.RecordedTokenUsages()
+			require.EqualValues(t, 5047, testutil.TotalInputTokens(tokenUsages))
+			require.EqualValues(t, 105, testutil.TotalOutputTokens(tokenUsages))
+
+			// Ensure we received exactly one prompt.
+			promptUsages := h.Recorder.RecordedPromptUsages()
+			require.Len(t, promptUsages, 1)
+		})
+	}
+}

--- a/testutil/bridge_server.go
+++ b/testutil/bridge_server.go
@@ -1,0 +1,111 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cdr.dev/slog"
+	"github.com/coder/aibridge"
+	"github.com/coder/aibridge/mcp"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+type BridgeConfig struct {
+	Ctx     context.Context
+	ActorID string
+
+	// Exactly one of Handler or Providers must be set.
+	Handler   http.Handler
+	Providers []aibridge.Provider
+
+	Recorder aibridge.Recorder
+
+	MCPProxiers map[string]mcp.ServerProxier
+
+	Logger  slog.Logger
+	Metrics *aibridge.Metrics
+	Tracer  trace.Tracer
+}
+
+type BridgeServer struct {
+	*httptest.Server
+	Client *http.Client
+}
+
+func NewBridgeServer(t testing.TB, cfg BridgeConfig) *BridgeServer {
+	t.Helper()
+
+	ctx := cfg.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if cfg.Tracer == nil {
+		cfg.Tracer = noop.NewTracerProvider().Tracer("aibridge/testutil")
+	}
+
+	if cfg.Handler == nil {
+		if len(cfg.Providers) == 0 {
+			t.Fatalf("BridgeConfig: must set either Handler or Providers")
+		}
+		if cfg.Recorder == nil {
+			t.Fatalf("BridgeConfig: Recorder is required when building a RequestBridge")
+		}
+
+		mgr := mcp.NewServerProxyManager(cfg.MCPProxiers, cfg.Tracer)
+		// Only init when there are proxiers. This keeps trace output consistent with
+		// tests that intentionally pass a nil/empty proxy map.
+		if len(cfg.MCPProxiers) > 0 {
+			if err := mgr.Init(ctx); err != nil {
+				t.Fatalf("init MCP manager: %v", err)
+			}
+		}
+
+		bridge, err := aibridge.NewRequestBridge(ctx, cfg.Providers, cfg.Recorder, mgr, cfg.Logger, cfg.Metrics, cfg.Tracer)
+		if err != nil {
+			t.Fatalf("create RequestBridge: %v", err)
+		}
+		cfg.Handler = bridge
+	}
+
+	srv := httptest.NewUnstartedServer(cfg.Handler)
+	srv.Config.BaseContext = func(_ net.Listener) context.Context {
+		if cfg.ActorID == "" {
+			return ctx
+		}
+		return aibridge.AsActor(ctx, cfg.ActorID, nil)
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	return &BridgeServer{
+		Server: srv,
+		Client: &http.Client{},
+	}
+}
+
+func (b *BridgeServer) NewProviderRequest(t testing.TB, provider string, body []byte) *http.Request {
+	t.Helper()
+
+	path := ""
+	switch provider {
+	case aibridge.ProviderAnthropic:
+		path = "/anthropic/v1/messages"
+	case aibridge.ProviderOpenAI:
+		path = "/openai/v1/chat/completions"
+	default:
+		t.Fatalf("unknown provider %q", provider)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, b.URL+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}

--- a/testutil/doc.go
+++ b/testutil/doc.go
@@ -1,0 +1,15 @@
+// Package testutil contains helpers for testing AIBridge.
+//
+// # Stability
+//
+// This package is intended for tests and examples within the Coder ecosystem.
+// It is not considered a stable public API.
+//
+// The goal is to make AIBridge tests:
+//   - easier to read
+//   - easier to extend
+//   - less reliant on copy/paste setup
+//
+// In particular, it provides typed accessors for txtar fixtures and small
+// harness structs for standing up mock upstream/MCP/bridge servers.
+package testutil

--- a/testutil/fixture_llm.go
+++ b/testutil/fixture_llm.go
@@ -1,0 +1,118 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	FixtureRequest              = "request"
+	FixtureStreamingResponse    = "streaming"
+	FixtureNonStreamingResponse = "non-streaming"
+
+	FixtureStreamingToolResponse    = "streaming/tool-call"
+	FixtureNonStreamingToolResponse = "non-streaming/tool-call"
+
+	FixtureResponse = "response"
+)
+
+// LLMFixture is a typed view over a TXTAR fixture used for bridged LLM
+// interactions (OpenAI/Anthropic-like request + streaming/non-streaming
+// responses).
+//
+// It knows how to:
+//   - derive a request body for streaming/non-streaming modes
+//   - select the correct upstream response for the Nth call
+//
+// It does NOT attempt to interpret or validate the JSON/SSE payload contents.
+type LLMFixture struct {
+	TXTAR TXTARFixture
+}
+
+func NewLLMFixture(txtarFixture TXTARFixture) (LLMFixture, error) {
+	if len(txtarFixture.Files) == 0 {
+		return LLMFixture{}, fmt.Errorf("empty txtar fixture")
+	}
+
+	// We require at minimum a request.
+	if !txtarFixture.Has(FixtureRequest) {
+		return LLMFixture{}, fmt.Errorf("missing %q section", FixtureRequest)
+	}
+
+	return LLMFixture{TXTAR: txtarFixture}, nil
+}
+
+func MustLLMFixture(t testing.TB, txtarFixture TXTARFixture) LLMFixture {
+	t.Helper()
+	f, err := NewLLMFixture(txtarFixture)
+	if err != nil {
+		t.Fatalf("create LLM fixture: %v", err)
+	}
+	return f
+}
+
+// RequestBody returns the request body with the stream flag set according to
+// streaming.
+func (f LLMFixture) RequestBody(streaming bool) ([]byte, error) {
+	body, ok := f.TXTAR.File(FixtureRequest)
+	if !ok {
+		// NewLLMFixture requires this, but keep it defensive.
+		return nil, fmt.Errorf("missing %q section", FixtureRequest)
+	}
+	return SetJSON(body, "stream", streaming)
+}
+
+// MustRequestBody is a convenience helper for tests.
+func (f LLMFixture) MustRequestBody(t testing.TB, streaming bool) []byte {
+	t.Helper()
+	body, err := f.RequestBody(streaming)
+	if err != nil {
+		t.Fatalf("fixture request body: %v", err)
+	}
+	return body
+}
+
+// HasToolCallResponses reports whether the fixture includes the */tool-call
+// response sections.
+func (f LLMFixture) HasToolCallResponses() bool {
+	return f.TXTAR.Has(FixtureStreamingToolResponse) || f.TXTAR.Has(FixtureNonStreamingToolResponse)
+}
+
+// Response returns the upstream response body for the given call number.
+//
+// call is 1-indexed.
+func (f LLMFixture) Response(call int, streaming bool) ([]byte, error) {
+	if call < 1 {
+		return nil, fmt.Errorf("call must be >= 1, got %d", call)
+	}
+
+	if call == 1 || !f.HasToolCallResponses() {
+		if streaming {
+			if !f.TXTAR.Has(FixtureStreamingResponse) {
+				return nil, fmt.Errorf("missing %q section", FixtureStreamingResponse)
+			}
+			return f.TXTAR.Files[FixtureStreamingResponse], nil
+		}
+
+		if !f.TXTAR.Has(FixtureNonStreamingResponse) {
+			return nil, fmt.Errorf("missing %q section", FixtureNonStreamingResponse)
+		}
+		return f.TXTAR.Files[FixtureNonStreamingResponse], nil
+	}
+
+	if call != 2 {
+		return nil, fmt.Errorf("unexpected call %d; this fixture only supports 1 or 2 calls", call)
+	}
+
+	if streaming {
+		if !f.TXTAR.Has(FixtureStreamingToolResponse) {
+			return nil, fmt.Errorf("missing %q section", FixtureStreamingToolResponse)
+		}
+		return f.TXTAR.Files[FixtureStreamingToolResponse], nil
+	}
+
+	if !f.TXTAR.Has(FixtureNonStreamingToolResponse) {
+		return nil, fmt.Errorf("missing %q section", FixtureNonStreamingToolResponse)
+	}
+	return f.TXTAR.Files[FixtureNonStreamingToolResponse], nil
+}

--- a/testutil/fixture_txtar.go
+++ b/testutil/fixture_txtar.go
@@ -1,0 +1,79 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/tools/txtar"
+)
+
+// TXTARFixture is a parsed txtar archive (see golang.org/x/tools/txtar) with a
+// convenient map-based API.
+//
+// Tests should prefer TXTARFixture over ad-hoc txtar.Parse + manual file maps.
+// It provides early validation and clearer error messages.
+type TXTARFixture struct {
+	Comment string
+	Files   map[string][]byte
+}
+
+func ParseTXTAR(data []byte) (TXTARFixture, error) {
+	if len(data) == 0 {
+		return TXTARFixture{}, fmt.Errorf("empty txtar input")
+	}
+
+	arc := txtar.Parse(data)
+
+	files := make(map[string][]byte, len(arc.Files))
+	for _, f := range arc.Files {
+		if f.Name == "" {
+			return TXTARFixture{}, fmt.Errorf("txtar contains a file with an empty name")
+		}
+		if _, exists := files[f.Name]; exists {
+			return TXTARFixture{}, fmt.Errorf("txtar contains duplicate file name %q", f.Name)
+		}
+		files[f.Name] = f.Data
+	}
+
+	return TXTARFixture{
+		Comment: string(arc.Comment),
+		Files:   files,
+	}, nil
+}
+
+func MustParseTXTAR(t testing.TB, data []byte) TXTARFixture {
+	t.Helper()
+	f, err := ParseTXTAR(data)
+	if err != nil {
+		t.Fatalf("parse txtar: %v", err)
+	}
+	return f
+}
+
+func (f TXTARFixture) Has(name string) bool {
+	_, ok := f.Files[name]
+	return ok
+}
+
+func (f TXTARFixture) File(name string) ([]byte, bool) {
+	b, ok := f.Files[name]
+	return b, ok
+}
+
+func (f TXTARFixture) MustFile(t testing.TB, name string) []byte {
+	t.Helper()
+	b, ok := f.File(name)
+	if !ok {
+		t.Fatalf("txtar missing section %q; have %v", name, sortedKeys(f.Files))
+	}
+	return b
+}
+
+func (f TXTARFixture) RequireFiles(t testing.TB, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		if !f.Has(name) {
+			t.Fatalf("txtar missing required section %q; have %v", name, sortedKeys(f.Files))
+		}
+	}
+}

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,0 +1,28 @@
+package testutil
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func sortedKeys[M ~map[string]V, V any](m M) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func mustNoError(t testing.TB, err error, format string, args ...any) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	prefix := ""
+	if format != "" {
+		prefix = fmt.Sprintf(format, args...) + ": "
+	}
+	t.Fatalf("%s%v", prefix, err)
+}

--- a/testutil/http_reflector.go
+++ b/testutil/http_reflector.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// HTTPReflectorServer is an httptest.Server that responds with a raw HTTP
+// response loaded from a fixture.
+//
+// The fixture bytes must be a complete HTTP response (status line, headers,
+// blank line, body) as accepted by http.ReadResponse.
+//
+// This is useful for simulating upstream error responses.
+type HTTPReflectorServer struct {
+	*httptest.Server
+}
+
+func NewHTTPReflectorServer(t testing.TB, ctx context.Context, rawHTTPResponse []byte) *HTTPReflectorServer {
+	t.Helper()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	s := &HTTPReflectorServer{}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mock, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(rawHTTPResponse)), r)
+		if err != nil {
+			t.Fatalf("read mock response: %v", err)
+		}
+		defer mock.Body.Close()
+
+		for key, values := range mock.Header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+
+		w.WriteHeader(mock.StatusCode)
+		_, err = io.Copy(w, mock.Body)
+		if err != nil {
+			t.Fatalf("copy mock response body: %v", err)
+		}
+	}))
+	srv.Config.BaseContext = func(_ net.Listener) context.Context {
+		return ctx
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	s.Server = srv
+	return s
+}

--- a/testutil/inspector.go
+++ b/testutil/inspector.go
@@ -1,0 +1,81 @@
+package testutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/coder/aibridge"
+)
+
+// Inspector provides a single place to access data needed for assertions.
+//
+// It is intentionally small; tests can always drop down to the underlying
+// Recorder/MCP/Upstream objects when needed.
+type Inspector struct {
+	Recorder *RecorderSpy
+	MCP      *MCPServer
+	Upstream *UpstreamServer
+}
+
+func NewInspector(recorder *RecorderSpy, mcpServer *MCPServer, upstream *UpstreamServer) *Inspector {
+	return &Inspector{Recorder: recorder, MCP: mcpServer, Upstream: upstream}
+}
+
+func (i *Inspector) UpstreamCalls() int {
+	if i == nil || i.Upstream == nil {
+		return 0
+	}
+	return i.Upstream.CallCount()
+}
+
+// RequireToolCalledOnceWithArgs asserts that:
+//   - the bridge recorded exactly one tool usage with the given name
+//   - the mock MCP server received exactly one call with matching args
+func (i *Inspector) RequireToolCalledOnceWithArgs(t testing.TB, tool string, wantArgs any) {
+	t.Helper()
+	if i == nil {
+		t.Fatalf("inspector is nil")
+	}
+	if i.Recorder == nil {
+		t.Fatalf("inspector Recorder is nil")
+	}
+	if i.MCP == nil {
+		t.Fatalf("inspector MCP is nil")
+	}
+
+	// Verify bridge-side record.
+	var toolUsages []*aibridge.ToolUsageRecord
+	for _, u := range i.Recorder.RecordedToolUsages() {
+		if u.Tool == tool {
+			toolUsages = append(toolUsages, u)
+		}
+	}
+	if len(toolUsages) != 1 {
+		t.Fatalf("tool usages for %q: got %d, want 1", tool, len(toolUsages))
+	}
+
+	wantJSON, err := json.Marshal(wantArgs)
+	if err != nil {
+		t.Fatalf("marshal wantArgs: %v", err)
+	}
+	gotJSON, err := json.Marshal(toolUsages[0].Args)
+	if err != nil {
+		t.Fatalf("marshal recorded tool args: %v", err)
+	}
+	if string(wantJSON) != string(gotJSON) {
+		t.Fatalf("recorded tool args mismatch\nwant: %s\ngot:  %s", string(wantJSON), string(gotJSON))
+	}
+
+	// Verify MCP-side receipt.
+	invocations := i.MCP.CallsByTool(tool)
+	if len(invocations) != 1 {
+		t.Fatalf("MCP calls for %q: got %d, want 1", tool, len(invocations))
+	}
+	gotJSON, err = json.Marshal(invocations[0])
+	if err != nil {
+		t.Fatalf("marshal MCP call args: %v", err)
+	}
+	if string(wantJSON) != string(gotJSON) {
+		t.Fatalf("MCP call args mismatch\nwant: %s\ngot:  %s", string(wantJSON), string(gotJSON))
+	}
+}

--- a/testutil/json.go
+++ b/testutil/json.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tidwall/sjson"
+)
+
+// SetJSON sets a JSON value at the given key/path (tidwall/sjson syntax) and
+// returns the updated JSON bytes.
+func SetJSON(in []byte, key string, val any) ([]byte, error) {
+	if len(in) == 0 {
+		return nil, fmt.Errorf("empty JSON input")
+	}
+	if key == "" {
+		return nil, fmt.Errorf("empty JSON key")
+	}
+
+	out, err := sjson.SetBytes(in, key, val)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func MustSetJSON(t testing.TB, in []byte, key string, val any) []byte {
+	t.Helper()
+	out, err := SetJSON(in, key, val)
+	mustNoError(t, err, "set JSON")
+	return out
+}

--- a/testutil/mcp_server.go
+++ b/testutil/mcp_server.go
@@ -1,0 +1,122 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"cdr.dev/slog"
+	"github.com/coder/aibridge/mcp"
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// ToolCoderListWorkspaces matches the tool name used throughout the current tests.
+	ToolCoderListWorkspaces = "coder_list_workspaces"
+)
+
+func DefaultCoderToolNames() []string {
+	return []string{
+		ToolCoderListWorkspaces,
+		"coder_list_templates",
+		"coder_template_version_parameters",
+		"coder_get_authenticated_user",
+		"coder_create_workspace_build",
+	}
+}
+
+type MCPToolResultFunc func(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error)
+
+type MCPServer struct {
+	*httptest.Server
+
+	callsMu sync.Mutex
+	calls   map[string][]any
+}
+
+type MCPServerOption func(*mcpServerConfig)
+
+type mcpServerConfig struct {
+	toolResultFn MCPToolResultFunc
+}
+
+func WithMCPToolResult(fn MCPToolResultFunc) MCPServerOption {
+	return func(cfg *mcpServerConfig) {
+		cfg.toolResultFn = fn
+	}
+}
+
+func NewMCPServer(t testing.TB, toolNames []string, opts ...MCPServerOption) *MCPServer {
+	t.Helper()
+
+	cfg := mcpServerConfig{
+		toolResultFn: func(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+			return mcplib.NewToolResultText("mock"), nil
+		},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	s := &MCPServer{calls: make(map[string][]any)}
+
+	mcpSrv := server.NewMCPServer(
+		"Mock MCP server",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	for _, name := range toolNames {
+		name := name // capture
+		tool := mcplib.NewTool(name, mcplib.WithDescription(fmt.Sprintf("Mock of the %s tool", name)))
+		mcpSrv.AddTool(tool, func(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+			s.addCall(request.Params.Name, request.Params.Arguments)
+			return cfg.toolResultFn(ctx, request)
+		})
+	}
+
+	h := server.NewStreamableHTTPServer(mcpSrv)
+	s.Server = httptest.NewServer(h)
+	t.Cleanup(s.Server.Close)
+
+	return s
+}
+
+func (s *MCPServer) addCall(tool string, args any) {
+	s.callsMu.Lock()
+	defer s.callsMu.Unlock()
+
+	s.calls[tool] = append(s.calls[tool], args)
+}
+
+func (s *MCPServer) CallsByTool(name string) []any {
+	s.callsMu.Lock()
+	defer s.callsMu.Unlock()
+
+	calls := s.calls[name]
+	out := make([]any, len(calls))
+	copy(out, calls)
+	return out
+}
+
+func (s *MCPServer) Proxiers(t testing.TB, serverName string, logger slog.Logger, tracer trace.Tracer) map[string]mcp.ServerProxier {
+	t.Helper()
+
+	proxy, err := mcp.NewStreamableHTTPServerProxy(serverName, s.URL, nil, nil, nil, logger, tracer)
+	mustNoError(t, err, "create MCP proxy")
+	return map[string]mcp.ServerProxier{proxy.Name(): proxy}
+}
+
+func (s *MCPServer) Handler() http.Handler {
+	if s.Server == nil {
+		return nil
+	}
+	return s.Server.Config.Handler
+}

--- a/testutil/recorder_spy.go
+++ b/testutil/recorder_spy.go
@@ -1,0 +1,142 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/aibridge"
+)
+
+var _ aibridge.Recorder = (*RecorderSpy)(nil)
+
+// RecorderSpy is a thread-safe in-memory implementation of [aibridge.Recorder]
+// intended for tests.
+//
+// It provides query helpers so tests can assert on recorded interceptions,
+// token/prompt usage, and tool usage.
+type RecorderSpy struct {
+	mu sync.Mutex
+
+	interceptions    []*aibridge.InterceptionRecord
+	tokenUsages      []*aibridge.TokenUsageRecord
+	userPrompts      []*aibridge.PromptUsageRecord
+	toolUsages       []*aibridge.ToolUsageRecord
+	interceptionsEnd map[string]time.Time
+}
+
+func (m *RecorderSpy) RecordInterception(ctx context.Context, req *aibridge.InterceptionRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.interceptions = append(m.interceptions, req)
+	return nil
+}
+
+func (m *RecorderSpy) RecordInterceptionEnded(ctx context.Context, req *aibridge.InterceptionRecordEnded) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.interceptionsEnd == nil {
+		m.interceptionsEnd = make(map[string]time.Time)
+	}
+	if !slices.ContainsFunc(m.interceptions, func(intc *aibridge.InterceptionRecord) bool { return intc.ID == req.ID }) {
+		return fmt.Errorf("interception id not found: %q", req.ID)
+	}
+	m.interceptionsEnd[req.ID] = req.EndedAt
+	return nil
+}
+
+func (m *RecorderSpy) RecordPromptUsage(ctx context.Context, req *aibridge.PromptUsageRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.userPrompts = append(m.userPrompts, req)
+	return nil
+}
+
+func (m *RecorderSpy) RecordTokenUsage(ctx context.Context, req *aibridge.TokenUsageRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tokenUsages = append(m.tokenUsages, req)
+	return nil
+}
+
+func (m *RecorderSpy) RecordToolUsage(ctx context.Context, req *aibridge.ToolUsageRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.toolUsages = append(m.toolUsages, req)
+	return nil
+}
+
+// RecordedTokenUsages returns a shallow clone of recorded token usages.
+func (m *RecorderSpy) RecordedTokenUsages() []*aibridge.TokenUsageRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.tokenUsages)
+}
+
+// RecordedPromptUsages returns a shallow clone of recorded prompt usages.
+func (m *RecorderSpy) RecordedPromptUsages() []*aibridge.PromptUsageRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.userPrompts)
+}
+
+// RecordedToolUsages returns a shallow clone of recorded tool usages.
+func (m *RecorderSpy) RecordedToolUsages() []*aibridge.ToolUsageRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.toolUsages)
+}
+
+// RecordedInterceptions returns a shallow clone of recorded interceptions.
+func (m *RecorderSpy) RecordedInterceptions() []*aibridge.InterceptionRecord {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.interceptions)
+}
+
+// RequireAllInterceptionsEnded fails the test if any recorded interception did
+// not receive a corresponding RecordInterceptionEnded call.
+func (m *RecorderSpy) RequireAllInterceptionsEnded(t testing.TB) {
+	t.Helper()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	gotEnded := 0
+	if m.interceptionsEnd != nil {
+		gotEnded = len(m.interceptionsEnd)
+	}
+
+	if len(m.interceptions) != gotEnded {
+		t.Fatalf("got %d interception ended calls, want %d", gotEnded, len(m.interceptions))
+	}
+	for _, intc := range m.interceptions {
+		if m.interceptionsEnd == nil {
+			t.Fatalf("interception with id %q has not been ended", intc.ID)
+		}
+		if _, ok := m.interceptionsEnd[intc.ID]; !ok {
+			t.Fatalf("interception with id %q has not been ended", intc.ID)
+		}
+	}
+}
+
+// TotalInputTokens sums input tokens from token usage records.
+func TotalInputTokens(in []*aibridge.TokenUsageRecord) int64 {
+	var total int64
+	for _, el := range in {
+		total += el.Input
+	}
+	return total
+}
+
+// TotalOutputTokens sums output tokens from token usage records.
+func TotalOutputTokens(in []*aibridge.TokenUsageRecord) int64 {
+	var total int64
+	for _, el := range in {
+		total += el.Output
+	}
+	return total
+}

--- a/testutil/upstream_server.go
+++ b/testutil/upstream_server.go
@@ -1,0 +1,261 @@
+package testutil
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// UpstreamRequest captures a single request received by an [UpstreamServer].
+//
+// It is intended for test assertions (e.g. validating headers, paths, and
+// request bodies).
+type UpstreamRequest struct {
+	Call   int
+	Method string
+	Path   string
+	Header http.Header
+	Body   []byte
+}
+
+// UpstreamServer is an httptest.Server that mimics an upstream LLM provider.
+//
+// It is driven by an [LLMFixture]. It chooses between the streaming and
+// non-streaming fixture responses based on the request body ("stream": true)
+// and the request path (AWS Bedrock uses a streaming-specific path).
+//
+// For injected-tool tests, it can serve a second response ("*/tool-call") on
+// the 2nd request.
+type UpstreamServer struct {
+	*httptest.Server
+
+	fixture LLMFixture
+
+	callCount atomic.Uint32
+
+	requestsMu sync.Mutex
+	requests   []UpstreamRequest
+
+	// statusCode is only applied for non-streaming responses, matching the current
+	// test behavior (streaming responses default to 200 once the stream begins).
+	statusCode atomic.Int32
+
+	responseMutator func(call int, resp []byte) []byte
+}
+
+type UpstreamOption func(*UpstreamServer)
+
+func WithUpstreamNonStreamingStatusCode(code int) UpstreamOption {
+	return func(s *UpstreamServer) {
+		s.statusCode.Store(int32(code))
+	}
+}
+
+func WithUpstreamResponseMutator(fn func(call int, resp []byte) []byte) UpstreamOption {
+	return func(s *UpstreamServer) {
+		s.responseMutator = fn
+	}
+}
+
+func NewUpstreamServer(t testing.TB, ctx context.Context, fixture LLMFixture, opts ...UpstreamOption) *UpstreamServer {
+	t.Helper()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	s := &UpstreamServer{fixture: fixture}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(s)
+		}
+	}
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := int(s.callCount.Add(1))
+
+		body, err := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if err != nil {
+			t.Fatalf("read upstream request body: %v", err)
+		}
+
+		s.recordRequest(call, r, body)
+
+		type msg struct {
+			Stream bool `json:"stream"`
+		}
+		var reqMsg msg
+		if err := json.Unmarshal(body, &reqMsg); err != nil {
+			t.Fatalf("unmarshal upstream request body: %v", err)
+		}
+
+		// AWS Bedrock uses a streaming-specific path suffix.
+		isStreaming := reqMsg.Stream || strings.HasSuffix(r.URL.Path, "invoke-with-response-stream")
+
+		if !isStreaming {
+			respBody, err := s.fixture.Response(call, false)
+			if err != nil {
+				t.Fatalf("select upstream response: %v", err)
+			}
+			if s.responseMutator != nil {
+				respBody = s.responseMutator(call, respBody)
+			}
+
+			code := int(s.statusCode.Load())
+			if code == 0 {
+				code = http.StatusOK
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
+			_, _ = w.Write(respBody)
+			return
+		}
+
+		// Streaming response.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		respBody, err := s.fixture.Response(call, true)
+		if err != nil {
+			t.Fatalf("select upstream response: %v", err)
+		}
+		if s.responseMutator != nil {
+			respBody = s.responseMutator(call, respBody)
+		}
+
+		scanner := bufio.NewScanner(bytes.NewReader(respBody))
+		// Allow large SSE lines; fixtures may exceed the default 64KiB scanner limit.
+		scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Fprintf(w, "%s\n", line)
+			flusher.Flush()
+		}
+
+		if err := scanner.Err(); err != nil {
+			http.Error(w, fmt.Sprintf("error reading fixture: %v", err), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.Config.BaseContext = func(_ net.Listener) context.Context {
+		return ctx
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	s.Server = srv
+	return s
+}
+
+func (s *UpstreamServer) recordRequest(call int, r *http.Request, body []byte) {
+	if s == nil {
+		return
+	}
+	if r == nil {
+		return
+	}
+
+	bodyCopy := make([]byte, len(body))
+	copy(bodyCopy, body)
+
+	s.requestsMu.Lock()
+	s.requests = append(s.requests, UpstreamRequest{
+		Call:   call,
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Header: r.Header.Clone(),
+		Body:   bodyCopy,
+	})
+	s.requestsMu.Unlock()
+}
+
+// Requests returns a snapshot of requests received by this server.
+func (s *UpstreamServer) Requests() []UpstreamRequest {
+	if s == nil {
+		return nil
+	}
+
+	s.requestsMu.Lock()
+	defer s.requestsMu.Unlock()
+
+	out := make([]UpstreamRequest, len(s.requests))
+	for i, req := range s.requests {
+		bodyCopy := make([]byte, len(req.Body))
+		copy(bodyCopy, req.Body)
+
+		out[i] = UpstreamRequest{
+			Call:   req.Call,
+			Method: req.Method,
+			Path:   req.Path,
+			Header: req.Header.Clone(),
+			Body:   bodyCopy,
+		}
+	}
+	return out
+}
+
+// LastRequest returns the most recently received request, if any.
+func (s *UpstreamServer) LastRequest() (UpstreamRequest, bool) {
+	if s == nil {
+		return UpstreamRequest{}, false
+	}
+
+	s.requestsMu.Lock()
+	defer s.requestsMu.Unlock()
+	if len(s.requests) == 0 {
+		return UpstreamRequest{}, false
+	}
+	req := s.requests[len(s.requests)-1]
+
+	bodyCopy := make([]byte, len(req.Body))
+	copy(bodyCopy, req.Body)
+
+	return UpstreamRequest{
+		Call:   req.Call,
+		Method: req.Method,
+		Path:   req.Path,
+		Header: req.Header.Clone(),
+		Body:   bodyCopy,
+	}, true
+}
+
+func (s *UpstreamServer) CallCount() int {
+	return int(s.callCount.Load())
+}
+
+func (s *UpstreamServer) RequireCallCountEventually(t testing.TB, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if s.CallCount() == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("upstream call count: got %d, want %d", s.CallCount(), want)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Refactors AIBridge integration tests to use a shared exported `testutil` harness and typed `.txtar` fixtures.

- Adds `testutil` package: `TXTARFixture`, `LLMFixture`, `UpstreamServer`, `MCPServer`, `BridgeServer`, `RecorderSpy`, `Inspector`
- Migrates bridge/metrics/trace integration tests to the new harness, removing legacy helpers and tuple-return setup
- Splits injected-tools integration tests into their own file

Fixes #73.

---

<details>
<summary>📋 Implementation Plan</summary>

# Refactor AIBridge tests: exported `testutil` harness + fixture structs

## Goals
- **Remove copy/paste** across integration tests by centralizing the common flow:
  1) load fixture → 2) start mock upstream (+ optional MCP) → 3) start AIBridge → 4) perform request → 5) assert via a single “inspector”.
- **Replace “helper functions with 4+ return values”** with **structs** (harness objects) so new features don’t keep accreting more tuple returns.
- **Keep `.txtar` fixtures** but make them *typed* (fixture structs with methods), so tests don’t manually `txtar.Parse` + `filesMap` + magic filenames.
- **Make helpers reusable outside this repo** by shipping an **exported** `github.com/coder/aibridge/testutil` package.

## Non-goals
- No changes to production request/streaming behavior.
- No fixture format migration (stay on `.txtar`).
- No attempt to fully abstract provider SDK parsing (Anthropic/OpenAI streaming accumulation can stay in tests initially).

---

## Proposed `testutil` package (exported)

### Key design principles
- **Prefer composition over mega-helper functions**: return *one* `Harness`/`Server` struct that exposes small methods.
- **Option pattern over extra return values**: adding capabilities should be additive without breaking call sites.
- **Defensive-by-default**: constructors validate fixtures early and fail fast with clear messages.

### Package layout (suggested)
- `testutil/fixture_txtar.go`: parse `.txtar`, expose a safe API.
- `testutil/fixture_llm.go`: provider/upstream fixture (request + streaming/non-streaming responses + optional tool-call responses).
- `testutil/upstream_server.go`: mock upstream server driven by `LLMFixture`.
- `testutil/http_reflector.go`: “raw HTTP response fixture” server (current `mockHTTPReflector` pattern).
- `testutil/mcp_server.go`: mock MCP server + call tracking + proxier creation.
- `testutil/recorder_spy.go`: `aibridge.Recorder` implementation + query helpers.
- `testutil/bridge_server.go`: start an AIBridge `httptest.Server` with actor context and configurable deps.
- `testutil/inspector.go`: one place to access assertion data (recorder + MCP calls + upstream call count).
- `testutil/doc.go`: package docs + “test-only / not API-stable” disclaimer + examples.

### Core types & responsibilities

#### 1) Fixtures
- `TXTARFixture`
  - Owns `.Comment` and a `map[string][]byte`.
  - Provides `File(name)` / `MustFile(name)` / `Has(name)`.
- `LLMFixture`
  - Created from a `TXTARFixture`.
  - Encodes the known sections (request, streaming, non-streaming, optional tool-call variants).
  - Provides:
    - `RequestBody(streaming bool) ([]byte, error)` (e.g. sets `stream=true` safely)
    - `Response(call int, streaming bool) ([]byte, error)` (supports 2-turn injected tool flows)

> Why: tests should stop knowing about `fixtureStreamingToolResponse` strings and “exactly 5 files”. The fixture struct should own that.

#### 2) Mock upstream server
- `type UpstreamServer struct { URL string; Calls atomic; ... }`
- Constructed with `LLMFixture` and options:
  - `WithResponseMutator(func(call int, resp []byte) []byte)` (keeps the escape hatch used today)
  - `WithStatusCode(int)`
- Behavior:
  - Reads request body once, determines streaming vs non-streaming (current logic).
  - Uses `LLMFixture.Response(call, streaming)` to select the correct response.
  - Provides `RequireCallCount(t, n)` / `EventuallyCallCount(t, n, timeout)`.

#### 3) Mock MCP server (fix PR72/63-style accretion)
Replace:
- `callAccumulator`
- `createMockMCPSrv`
- `setupMCPServerProxiesForTest` (map + accumulator return)

With:
- `type MCPServer struct { Server *httptest.Server; calls map[...]... }`
- Methods:
  - `CallsByTool(name string) []any`
  - `Proxiers(t, tracer, logger) map[string]mcp.ServerProxier` (or `Proxier()` + `Name()`)
  - `Close()` via `t.Cleanup` in constructor

#### 4) Recorder + Inspector
- `RecorderSpy` (exported) implements `aibridge.Recorder`
  - Thread-safe slices for interceptions/token/prompt/tool usage.
  - Convenience queries:
    - `TokenUsages() []*aibridge.TokenUsageRecord`
    - `ToolUsages() []*aibridge.ToolUsageRecord`
    - `RequireAllInterceptionsEnded(t)`
- `Inspector`
  - Holds pointers to:
    - `RecorderSpy`
    - `MCPServer` (optional)
    - `UpstreamServer` (optional)
  - Provides higher-level helpers:
    - `RequireToolCalled(t, tool string, wantArgs any)` (checks both recorded tool usage *and* MCP receipt)
    - `UpstreamCalls() int`

#### 5) AIBridge test server / harness
- `BridgeServer` (or `Harness`)
  - Starts `aibridge.NewRequestBridge(...)` and wraps it in `httptest.Server`.
  - Ensures actor context is set (current `BaseContext` pattern).
  - Holds the `*http.Client` used by tests.
  - Provides:
    - `Do(req *http.Request) (*http.Response, error)`
    - `NewProviderRequest(provider string, body []byte) (*http.Request, error)` (replaces `createOpenAIChatCompletionsReq` / `createAnthropicMessagesReq`).

<details>
<summary>📎 API sketch (example usage)</summary>

```go
fixture := testutil.MustParseTXTAR(t, antSingleInjectedTool)
llm := testutil.MustLLMFixture(fixture)

upstream := testutil.NewUpstreamServer(t, t.Context(), llm,
  testutil.WithInjectedToolSecondResponse(llm),
)

mcpSrv := testutil.NewMCPServer(t, testutil.CoderToolset())
rec := testutil.NewRecorderSpy()

bridge := testutil.NewBridgeServer(t, testutil.BridgeConfig{
  Ctx:      t.Context(),
  ActorID:  userID,
  Providers: []aibridge.Provider{aibridge.NewAnthropicProvider(anthropicCfg(upstream.URL(), apiKey), nil)},
  Recorder:  rec,
  MCPProxiers: mcpSrv.Proxiers(t, testTracer),
  Tracer:   testTracer,
})

reqBody := testutil.Must(llm.RequestBody(streaming))
req := bridge.MustNewProviderRequest(aibridge.ProviderAnthropic, reqBody)
resp := bridge.MustDo(req)

defer resp.Body.Close()

ins := testutil.NewInspector(rec, mcpSrv, upstream)
ins.RequireToolCalled(t, mockToolName, map[string]any{"owner": "admin"})
upstream.RequireCallCountEventually(t, 2)
```

</details>

---

## Migration plan (mixed: refactor big file early, but keep incremental safety)

### Phase 0 — Baseline + safety rails
1. Add `testutil` package skeleton with docs (`doc.go`) and a clear “**test-only / API may change**” disclaimer.
2. Add a small compile-time check somewhere in `testutil` to ensure it **doesn’t import** `aibridge_test` or rely on `_test.go` symbols.

### Phase 1 — Move the lowest-risk helpers first
1. Extract `mockRecorderClient` into `testutil.RecorderSpy` (keep method names close to today to simplify migration).
2. Extract `.txtar` parsing helpers:
   - `filesMap` → `testutil.MustParseTXTAR` returning `TXTARFixture`.
   - `setJSON` wrapper (if currently local) → `testutil.SetJSON` / `WithJSONField`.
3. Extract request builders:
   - `createAnthropicMessagesReq` / `createOpenAIChatCompletionsReq` → `BridgeServer.NewProviderRequest(...)`.

### Phase 2 — Fix the tech-debt hotspots (PR72/PR63 patterns)
1. Implement `testutil.MCPServer` and move `callAccumulator` inside it.
2. Replace `setupMCPServerProxiesForTest` usages with `mcpSrv.Proxiers(...)`.
3. Update injected-tool tests to stop passing around `map[string]mcp.ServerProxier` and `*callAccumulator`.

### Phase 3 — Rewrite `bridge_integration_test.go` early (reduce the 1900+ line “god file”)
1. Split the file by concern (examples):
   - `bridge_integration_anthropic_test.go`
   - `bridge_integration_openai_test.go`
   - `bridge_integration_injected_tools_test.go`
   - `bridge_integration_errors_test.go`
   - `bridge_integration_passthrough_test.go`
2. Introduce `testutil.UpstreamServer` and migrate the “standard flow” tests (simple/builtin-tool/injected-tool) to the new harness.
3. Keep escape hatches:
   - For tests that need full raw HTTP response fixtures, use `testutil.HTTPReflectorServer`.

### Phase 4 — Migrate metrics + trace integration tests
1. Replace `newTestSrv` with `testutil.NewBridgeServer` (or reuse the same `BridgeServer` type).
2. Keep span/metrics assertions local, but share:
   - server startup
   - recorder spy
   - request builders

### Phase 5 — Cleanup + enforce the new pattern
1. Delete old helpers once all call sites are migrated:
   - `setupInjectedToolTest`
   - `setupMCPServerProxiesForTest`
   - `callAccumulator`
   - provider-specific request builders
2. Add a short “how to write a new test” section (either in `testutil/doc.go` or `README.md`), showing the new preferred pattern.

---

## Acceptance criteria (what “done” looks like)
- Tests no longer manually do `txtar.Parse(...)` + `filesMap(...)`.
- No helper returns a 4-tuple; complex setup returns a single struct.
- Injected-tools tests don’t mention `callAccumulator` or raw `proxies` maps.
- Adding a new provider fixture-driven test requires only:
  - pick fixture
  - choose streaming bool
  - configure bridge
  - assertions
- `bridge_integration_test.go` is split and substantially smaller.

<details>
<summary>⚠️ Risks / mitigations</summary>

- **Exported helper API churn**: keep the exported surface area small; hide most fields; use options for extension.
- **Cross-repo reuse** (`coder`): avoid embedding local fixture paths in `testutil`; accept `[]byte` fixtures or `fs.FS`.
- **Accidental prod import**: clearly document “test-only” and keep package name `testutil` (discourages production use).

</details>

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.2` • Thinking: `xhigh`_
