### PR TITLE
perf: eliminate unnecessary json marshalling for anthropic requests to bridge

### DIFF
--- a/intercept/messages/paramswrap.go
+++ b/intercept/messages/paramswrap.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
-	"github.com/coder/aibridge/utils"
 )
 
 // MessageNewParamsWrapper exists because the "stream" param is not included in anthropic.MessageNewParams.
@@ -23,18 +22,30 @@ func (b MessageNewParamsWrapper) MarshalJSON() ([]byte, error) {
 }
 
 func (b *MessageNewParamsWrapper) UnmarshalJSON(raw []byte) error {
-	convertedRaw, err := convertStringContentToArray(raw)
+	// Parse JSON once and extract both stream field and do content conversion
+	// to avoid double-parsing the same payload.
+	var modifiedJSON map[string]any
+	if err := json.Unmarshal(raw, &modifiedJSON); err != nil {
+		return err
+	}
+
+	// Extract stream field from already-parsed map
+	if stream, ok := modifiedJSON["stream"].(bool); ok {
+		b.Stream = stream
+	}
+
+	// Convert string content to array format if needed
+	if _, hasMessages := modifiedJSON["messages"]; hasMessages {
+		convertStringContentRecursive(modifiedJSON)
+	}
+
+	// Marshal back for SDK parsing
+	convertedRaw, err := json.Marshal(modifiedJSON)
 	if err != nil {
 		return err
 	}
 
-	err = b.MessageNewParams.UnmarshalJSON(convertedRaw)
-	if err != nil {
-		return err
-	}
-
-	b.Stream = utils.ExtractJSONField[bool](raw, "stream")
-	return nil
+	return b.MessageNewParams.UnmarshalJSON(convertedRaw)
 }
 
 func (b *MessageNewParamsWrapper) lastUserPrompt() (*string, error) {
@@ -69,31 +80,11 @@ func (b *MessageNewParamsWrapper) lastUserPrompt() (*string, error) {
 	return nil, nil
 }
 
-// convertStringContentToArray converts string content to array format for Anthropic messages.
-// https://docs.anthropic.com/en/api/messages#body-messages
-//
-// Each input message content may be either a single string or an array of content blocks, where each block has a
-// specific type. Using a string for content is shorthand for an array of one content block of type "text".
-func convertStringContentToArray(raw []byte) ([]byte, error) {
-	var modifiedJSON map[string]any
-	if err := json.Unmarshal(raw, &modifiedJSON); err != nil {
-		return raw, err
-	}
-
-	// Check if messages exist and need content conversion
-	if _, hasMessages := modifiedJSON["messages"]; hasMessages {
-		convertStringContentRecursive(modifiedJSON)
-
-		// Marshal back to JSON
-		return json.Marshal(modifiedJSON)
-	}
-
-	return raw, nil
-}
-
 // convertStringContentRecursive recursively scans JSON data and converts string "content" fields
-// to proper text block arrays where needed for Anthropic SDK compatibility
-func convertStringContentRecursive(data any) {
+// to proper text block arrays where needed for Anthropic SDK compatibility.
+// Returns true if any modifications were made.
+func convertStringContentRecursive(data any) bool {
+	modified := false
 	switch v := data.(type) {
 	case map[string]any:
 		// Check if this object has a "content" field with string value
@@ -107,21 +98,27 @@ func convertStringContentRecursive(data any) {
 							"text": contentStr,
 						},
 					}
+					modified = true
 				}
 			}
 		}
 
 		// Recursively process all values in the map
 		for _, value := range v {
-			convertStringContentRecursive(value)
+			if convertStringContentRecursive(value) {
+				modified = true
+			}
 		}
 
 	case []any:
 		// Recursively process all items in the array
 		for _, item := range v {
-			convertStringContentRecursive(item)
+			if convertStringContentRecursive(item) {
+				modified = true
+			}
 		}
 	}
+	return modified
 }
 
 // shouldConvertContentField determines if a "content" string field should be converted to text block array


### PR DESCRIPTION
The actions of determining whether to use Anthropic's streaming APIs and ensuring a uniform message payload format used to unmarshal and remarshal the same payload twice. This PR ensures we unmarshal once, do both, and then remarshal once.