### PR TITLE
bug: add missing provider consts re-export

### DIFF
--- a/api.go
+++ b/api.go
@@ -13,7 +13,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Type + function aliases for backwards compatibility.
+// Const + Type + function aliases for backwards compatibility.
+const (
+	ProviderAnthropic = config.ProviderAnthropic
+	ProviderOpenAI    = config.ProviderOpenAI
+)
+
 type (
 	Metrics = metrics.Metrics
 


### PR DESCRIPTION
Fixes undefined error when building coder using `aibridge` from main branch:

```
enterprise/aibridgeproxyd/aibridgeproxyd.go:331:19: undefined: aibridge.ProviderAnthropic
enterprise/aibridgeproxyd/aibridgeproxyd.go:333:19: undefined: aibridge.ProviderOpenAI
```