### PR TITLE
fix: increase circuit breaker timeout in TestCircuitBreaker_PerModelIsolation

### DIFF
--- a/circuit_breaker_integration_test.go
+++ b/circuit_breaker_integration_test.go
@@ -607,7 +607,7 @@ func TestCircuitBreaker_PerModelIsolation(t *testing.T) {
 	cbConfig := &config.CircuitBreaker{
 		FailureThreshold: 2,
 		Interval:         time.Minute,
-		Timeout:          50 * time.Millisecond,
+		Timeout:          500 * time.Millisecond,
 		MaxRequests:      1,
 	}
 	prov := provider.NewAnthropic(config.Anthropic{


### PR DESCRIPTION
The 50ms timeout was too short and could expire between tripping the circuit and verifying it's open, causing the circuit to transition to half-open and allow a probe request through (returning 429 instead of 503).

Fixes #132