### PR TITLE
test: verify upstream errors are relayed to client in streaming chatcompletions

### DIFF
--- a/intercept/chatcompletions/streaming_test.go
+++ b/intercept/chatcompletions/streaming_test.go
@@ -1,14 +1,13 @@
 package chatcompletions
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
 	"cdr.dev/slog/v3"
-	"cdr.dev/slog/v3/sloggers/sloghuman"
+	"cdr.dev/slog/v3/sloggers/slogtest"
 	"github.com/coder/aibridge/config"
 	"github.com/coder/aibridge/internal/testutil"
 	"github.com/google/uuid"
@@ -85,7 +84,7 @@ func TestStreamingInterception_RelaysUpstreamErrorToClient(t *testing.T) {
 			tracer := otel.Tracer("test")
 			interceptor := NewStreamingInterceptor(uuid.New(), req, cfg, tracer)
 
-			logger := slog.Make(sloghuman.Sink(io.Discard))
+			logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: false}).Leveled(slog.LevelDebug)
 			interceptor.Setup(logger, &testutil.MockRecorder{}, nil)
 
 			// Create test request


### PR DESCRIPTION
## Description

Adds unit tests to verify that upstream provider errors are correctly relayed to clients before streaming starts.
This was introduced after testing with providers where 429 (rate limit) responses appeared to be ignored. Investigation confirmed that aibridge was correctly relaying these errors, the issue was on the client side. These tests document and verify this behavior.

## Changes

* Added `TestStreamingInterception_RelaysUpstreamErrorToClient`
* Tests cover 400 (bad request), 429 (rate limit), and 500 (internal server error) responses