### PR TITLE
feat: add extra headers support to responses endpoint

### DIFF
--- a/intercept/responses/base.go
+++ b/intercept/responses/base.go
@@ -52,6 +52,12 @@ type responsesInterceptionBase struct {
 func (i *responsesInterceptionBase) newResponsesService() responses.ResponseService {
 	opts := []option.RequestOption{option.WithBaseURL(i.cfg.BaseURL), option.WithAPIKey(i.cfg.Key)}
 
+	// Add extra headers if configured.
+	// Some providers require additional headers that are not added by the SDK.
+	for key, value := range i.cfg.ExtraHeaders {
+		opts = append(opts, option.WithHeader(key, value))
+	}
+
 	// Add API dump middleware if configured
 	if mw := apidump.NewMiddleware(i.cfg.APIDumpDir, config.ProviderOpenAI, i.Model(), i.id, i.logger, quartz.NewReal()); mw != nil {
 		opts = append(opts, option.WithMiddleware(mw))


### PR DESCRIPTION
## Description

Adds support for forwarding extra headers to the upstream provider when using OpenAI's `/responses` endpoint. This mirrors the existing functionality in the chat completions endpoint, ensuring Copilot-required headers (like `Editor-Version` and `Copilot-Integration-Id`) are properly forwarded.

## Changes

* Added `ExtraHeaders` iteration in `responsesInterceptionBase.newResponsesService()` to append configured headers to outgoing requests
* Added integration test `Responses_ForwardsHeadersToUpstream` to verify Copilot headers are forwarded and non-Copilot headers are filtered

Follow-up from: https://github.com/coder/aibridge/pull/137
Related to: https://github.com/coder/internal/issues/1235