### PR TITLE
chore: upgrade to go1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/aibridge
 
-go 1.24.6
+go 1.25.6
 
 // Misc libs.
 require (


### PR DESCRIPTION
coder/coder is now on go1.25, which was our only blocker