### PR TITLE
fix: add missing pass through paths

### DIFF
--- a/provider/anthropic.go
+++ b/provider/anthropic.go
@@ -72,6 +72,7 @@ func (p *Anthropic) PassthroughRoutes() []string {
 		"/v1/models",
 		"/v1/models/", // See https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux.
 		"/v1/messages/count_tokens",
+		"/api/event_logging/",
 	}
 }
 

--- a/provider/copilot.go
+++ b/provider/copilot.go
@@ -87,6 +87,7 @@ func (p *Copilot) PassthroughRoutes() []string {
 		"/models/",
 		"/agents/",
 		"/mcp/",
+		"/.well-known/",
 	}
 }
 


### PR DESCRIPTION
- Added `/api/event_logging/` to Anthropic's passthrough routes
- Added `/.well-known/` to Copilot's passthrough routes

Closes: https://github.com/coder/aibridge/issues/153