### PR TITLE
chore: cleanup accidental guessClient case

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -363,8 +363,6 @@ func guessClient(r *http.Request) string {
 		return ClientKilo
 	case strings.HasPrefix(userAgent, "roo-code/") || originator == "roo-code":
 		return ClientRoo
-	case strings.HasPrefix(userAgent, "copilot"):
-		return ClientCursor
 	case r.Header.Get("x-cursor-client-version") != "":
 		return ClientCursor
 	}


### PR DESCRIPTION
Removes case in `guessClient` function that should not exist in the first place.
Thank you @pymq for spotting that :https://github.com/coder/aibridge/pull/158#discussion_r2868923854