### PR TITLE
chore: retract v1.0.8 due to unresolved conflict marker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/coder/aibridge
 
 go 1.25.6
 
+retract v1.0.8 // contains unresolved conflict marker from cherry-pick
+
 // Misc libs.
 require (
 	cdr.dev/slog/v3 v3.0.0


### PR DESCRIPTION
Retracts v1.0.8 which was cached by the Go module proxy with an unresolved conflict marker from a cherry-pick. The fixed version is available as v1.0.9.

Related to internal Slack thread: https://codercom.slack.com/archives/C096PFVBZKN/p1773071251414289