### PR TITLE
feat: add Coder Agents client detection

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,16 +10,17 @@ type Client string
 const (
 	// Possible values for the "client" field in interception records.
 	// Must be kept in sync with documentation: https://github.com/coder/coder/blob/90c11f3386578da053ec5cd9f1475835b980e7c7/docs/ai-coder/ai-bridge/monitoring.md?plain=1#L36-L44
-	ClientClaudeCode Client = "Claude Code"
-	ClientCodex      Client = "Codex"
-	ClientZed        Client = "Zed"
-	ClientCopilotVSC Client = "GitHub Copilot (VS Code)"
-	ClientCopilotCLI Client = "GitHub Copilot (CLI)"
-	ClientKilo       Client = "Kilo Code"
-	ClientMux        Client = "Mux"
-	ClientRoo        Client = "Roo Code"
-	ClientCursor     Client = "Cursor"
-	ClientUnknown    Client = "Unknown"
+	ClientClaudeCode  Client = "Claude Code"
+	ClientCodex       Client = "Codex"
+	ClientZed         Client = "Zed"
+	ClientCopilotVSC  Client = "GitHub Copilot (VS Code)"
+	ClientCopilotCLI  Client = "GitHub Copilot (CLI)"
+	ClientKilo        Client = "Kilo Code"
+	ClientCoderAgents Client = "Coder Agents"
+	ClientMux         Client = "Mux"
+	ClientRoo         Client = "Roo Code"
+	ClientCursor      Client = "Cursor"
+	ClientUnknown     Client = "Unknown"
 )
 
 // guessClient attempts to guess the client application from the request headers.
@@ -47,6 +48,8 @@ func guessClient(r *http.Request) Client {
 		return ClientKilo
 	case strings.HasPrefix(userAgent, "roo-code/") || originator == "roo-code":
 		return ClientRoo
+	case strings.HasPrefix(userAgent, "coder-agents/"):
+		return ClientCoderAgents
 	case r.Header.Get("x-cursor-client-version") != "":
 		return ClientCursor
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -67,6 +67,16 @@ func TestGuessClient(t *testing.T) {
 			wantClient: ClientRoo,
 		},
 		{
+			name:       "coder_agents",
+			userAgent:  "coder-agents/v2.24.0 (linux/amd64)",
+			wantClient: ClientCoderAgents,
+		},
+		{
+			name:       "coder_agents_dev",
+			userAgent:  "coder-agents/v0.0.0-devel (darwin/arm64)",
+			wantClient: ClientCoderAgents,
+		},
+		{
 			name:       "cursor_x_cursor_client_version",
 			userAgent:  "connect-es/1.6.1",
 			headers:    map[string]string{"X-Cursor-client-version": "0.50.0"},

--- a/session.go
+++ b/session.go
@@ -65,6 +65,8 @@ func guessSessionID(client Client, r *http.Request) *string {
 		return cleanRef(r.Header.Get("X-Client-Session-Id"))
 	case ClientKilo:
 		return cleanRef(r.Header.Get("X-KILOCODE-TASKID"))
+	case ClientCoderAgents:
+		return nil // Session ID support planned in a follow-up.
 	case ClientRoo:
 		return nil // RooCode doesn't send a session ID.
 	case ClientCursor:

--- a/session_test.go
+++ b/session_test.go
@@ -125,6 +125,11 @@ func TestGuessSessionID(t *testing.T) {
 			name:   "kilo_without_task_id",
 			client: ClientKilo,
 		},
+		// Coder Agents.
+		{
+			name:   "coder_agents_returns_empty",
+			client: ClientCoderAgents,
+		},
 		// Roo.
 		{
 			name:   "roo_returns_empty",


### PR DESCRIPTION
Add `ClientCoderAgents` client detection matching the `coder-agents/` User-Agent prefix set by coder/coder#22965.