### PR TITLE
feat: recognise Charm Crush client

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ const (
 	ClientCopilotCLI  Client = "GitHub Copilot (CLI)"
 	ClientKilo        Client = "Kilo Code"
 	ClientCoderAgents Client = "Coder Agents"
+	ClientCrush       Client = "Charm Crush"
 	ClientMux         Client = "Mux"
 	ClientRoo         Client = "Roo Code"
 	ClientCursor      Client = "Cursor"
@@ -50,6 +51,8 @@ func guessClient(r *http.Request) Client {
 		return ClientRoo
 	case strings.HasPrefix(userAgent, "coder-agents/"):
 		return ClientCoderAgents
+	case strings.HasPrefix(userAgent, "charm crush/"):
+		return ClientCrush
 	case r.Header.Get("x-cursor-client-version") != "":
 		return ClientCursor
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -77,6 +77,11 @@ func TestGuessClient(t *testing.T) {
 			wantClient: ClientCoderAgents,
 		},
 		{
+			name:       "charm_crush",
+			userAgent:  "Charm Crush/0.1.11",
+			wantClient: ClientCrush,
+		},
+		{
 			name:       "cursor_x_cursor_client_version",
 			userAgent:  "connect-es/1.6.1",
 			headers:    map[string]string{"X-Cursor-client-version": "0.50.0"},


### PR DESCRIPTION
Adds `Charm Crush` client recognition to `guessClient` based on user agent header added in https://github.com/charmbracelet/crush/pull/2357/changes#diff-f48445f706f26bd59d7bae605c4445d3c178237d2489223bf9c1a813417d9713L196