### PR TITLE
feat: aibrige BYOK for OpenAI

### DIFF
--- a/provider/openai.go
+++ b/provider/openai.go
@@ -104,7 +104,7 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 	// In centralized mode Authorization is absent, so cfg keeps the
 	// centralized key unchanged.
 	//
-	// In BYOK mode the user's bearer token is in Authorization. Replace
+	// In BYOK mode the user's credential is in Authorization. Replace
 	// the centralized key with it so the SDK forwards it upstream.
 	if token := utils.ExtractBearerToken(r.Header.Get("Authorization")); token != "" {
 		cfg.Key = token

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -22,8 +22,6 @@ import (
 const (
 	routeChatCompletions = "/chat/completions" // https://platform.openai.com/docs/api-reference/chat
 	routeResponses       = "/responses"        // https://platform.openai.com/docs/api-reference/responses
-
-	chatGPTBaseURL = "https://chatgpt.com/backend-api/codex"
 )
 
 var openAIOpenErrorResponse = func() []byte {
@@ -110,14 +108,6 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 	// the centralized key with it so it is forwarded upstream.
 	if token := utils.ExtractBearerToken(r.Header.Get("Authorization")); token != "" {
 		cfg.Key = token
-	}
-
-	// ChatGPT subscription OAuth tokens (Plus/Pro) use a different backend
-	// than platform API keys. The Chatgpt-Account-Id header is set by Codex
-	// when authenticating via a ChatGPT subscription, indicating that requests
-	// must be routed to the subscription-specific backend.
-	if r.Header.Get("Chatgpt-Account-Id") != "" {
-		cfg.BaseURL = chatGPTBaseURL
 	}
 
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -22,6 +22,8 @@ import (
 const (
 	routeChatCompletions = "/chat/completions" // https://platform.openai.com/docs/api-reference/chat
 	routeResponses       = "/responses"        // https://platform.openai.com/docs/api-reference/responses
+
+	chatGPTBaseURL = "https://chatgpt.com/backend-api/codex"
 )
 
 var openAIOpenErrorResponse = func() []byte {
@@ -105,7 +107,7 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 	// centralized key unchanged.
 	//
 	// In BYOK mode the user's credential is in Authorization. Replace
-	// the centralized key with it so the SDK forwards it upstream.
+	// the centralized key with it so it is forwarded upstream.
 	if token := utils.ExtractBearerToken(r.Header.Get("Authorization")); token != "" {
 		cfg.Key = token
 	}
@@ -115,7 +117,7 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 	// when authenticating via a ChatGPT subscription, indicating that requests
 	// must be routed to the subscription-specific backend.
 	if r.Header.Get("Chatgpt-Account-Id") != "" {
-		cfg.BaseURL = "https://chatgpt.com/backend-api/codex"
+		cfg.BaseURL = chatGPTBaseURL
 	}
 
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -110,6 +110,14 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 		cfg.Key = token
 	}
 
+	// ChatGPT subscription OAuth tokens (Plus/Pro) use a different backend
+	// than platform API keys. The Chatgpt-Account-Id header is set by Codex
+	// when authenticating via a ChatGPT subscription, indicating that requests
+	// must be routed to the subscription-specific backend.
+	if r.Header.Get("Chatgpt-Account-Id") != "" {
+		cfg.BaseURL = "https://chatgpt.com/backend-api/codex"
+	}
+
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())
 	switch path {
 	case routeChatCompletions:

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coder/aibridge/intercept/chatcompletions"
 	"github.com/coder/aibridge/intercept/responses"
 	"github.com/coder/aibridge/tracing"
+	"github.com/coder/aibridge/utils"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -96,6 +97,19 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 
 	var interceptor intercept.Interceptor
 
+	cfg := p.cfg
+	// At this point the request contains only LLM provider headers. Any
+	// Coder-specific authentication has already been stripped.
+	//
+	// In centralized mode Authorization is absent, so cfg keeps the
+	// centralized key unchanged.
+	//
+	// In BYOK mode the user's bearer token is in Authorization. Replace
+	// the centralized key with it so the SDK forwards it upstream.
+	if token := utils.ExtractBearerToken(r.Header.Get("Authorization")); token != "" {
+		cfg.Key = token
+	}
+
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())
 	switch path {
 	case routeChatCompletions:
@@ -105,9 +119,9 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 		}
 
 		if req.Stream {
-			interceptor = chatcompletions.NewStreamingInterceptor(id, &req, p.cfg, r.Header, p.AuthHeader(), tracer)
+			interceptor = chatcompletions.NewStreamingInterceptor(id, &req, cfg, r.Header, p.AuthHeader(), tracer)
 		} else {
-			interceptor = chatcompletions.NewBlockingInterceptor(id, &req, p.cfg, r.Header, p.AuthHeader(), tracer)
+			interceptor = chatcompletions.NewBlockingInterceptor(id, &req, cfg, r.Header, p.AuthHeader(), tracer)
 		}
 
 	case routeResponses:
@@ -120,9 +134,9 @@ func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, trace
 			return nil, fmt.Errorf("unmarshal request body: %w", err)
 		}
 		if reqPayload.Stream() {
-			interceptor = responses.NewStreamingInterceptor(id, reqPayload, p.cfg, r.Header, p.AuthHeader(), tracer)
+			interceptor = responses.NewStreamingInterceptor(id, reqPayload, cfg, r.Header, p.AuthHeader(), tracer)
 		} else {
-			interceptor = responses.NewBlockingInterceptor(id, reqPayload, p.cfg, r.Header, p.AuthHeader(), tracer)
+			interceptor = responses.NewBlockingInterceptor(id, reqPayload, cfg, r.Header, p.AuthHeader(), tracer)
 		}
 
 	default:
@@ -144,6 +158,12 @@ func (p *OpenAI) AuthHeader() string {
 func (p *OpenAI) InjectAuthHeader(headers *http.Header) {
 	if headers == nil {
 		headers = &http.Header{}
+	}
+
+	// BYOK: if the request already carries user-supplied credentials,
+	// do not overwrite them with the centralized key.
+	if headers.Get("Authorization") != "" {
+		return
 	}
 
 	headers.Set(p.AuthHeader(), "Bearer "+p.cfg.Key)

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -202,6 +202,30 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			setHeaders:        map[string]string{},
 			wantAuthorization: "Bearer centralized-key",
 		},
+		// X-Api-Key should not appear in production since clients use Authorization,
+		// but ensure it is stripped if it does arrive.
+		{
+			name:         "ChatCompletions_BYOK_XApiKeyStripped",
+			route:        routeChatCompletions,
+			requestBody:  `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
+			responseBody: chatCompletionResponse,
+			setHeaders: map[string]string{
+				"Authorization": "Bearer user-token",
+				"X-Api-Key":     "some-key",
+			},
+			wantAuthorization: "Bearer user-token",
+		},
+		{
+			name:         "Responses_BYOK_XApiKeyStripped",
+			route:        routeResponses,
+			requestBody:  `{"model": "gpt-5", "input": "hello", "stream": false}`,
+			responseBody: responsesAPIResponse,
+			setHeaders: map[string]string{
+				"Authorization": "Bearer user-token",
+				"X-Api-Key":     "some-key",
+			},
+			wantAuthorization: "Bearer user-token",
+		},
 	}
 
 	for _, tc := range tests {

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -171,7 +171,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 		wantAuthorization string
 	}{
 		{
-			name:              "ChatCompletions_BYOK_BearerToken",
+			name:              "ChatCompletions_BYOK",
 			route:             routeChatCompletions,
 			requestBody:       `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
 			responseBody:      chatCompletionResponse,
@@ -179,7 +179,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			wantAuthorization: "Bearer user-token",
 		},
 		{
-			name:              "ChatCompletions_Centralized_UsesCentralizedKey",
+			name:              "ChatCompletions_Centralized",
 			route:             routeChatCompletions,
 			requestBody:       `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
 			responseBody:      chatCompletionResponse,
@@ -187,7 +187,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			wantAuthorization: "Bearer centralized-key",
 		},
 		{
-			name:              "Responses_BYOK_BearerToken",
+			name:              "Responses_BYOK",
 			route:             routeResponses,
 			requestBody:       `{"model": "gpt-5", "input": "hello", "stream": false}`,
 			responseBody:      responsesAPIResponse,
@@ -195,7 +195,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			wantAuthorization: "Bearer user-token",
 		},
 		{
-			name:              "Responses_Centralized_UsesCentralizedKey",
+			name:              "Responses_Centralized",
 			route:             routeResponses,
 			requestBody:       `{"model": "gpt-5", "input": "hello", "stream": false}`,
 			responseBody:      responsesAPIResponse,

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -159,71 +159,6 @@ func generateResponsesPayload(payloadSize int, inputCount int, stream bool) []by
 	return bodyBytes
 }
 
-func TestOpenAI_CreateInterceptor(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name         string
-		route        string
-		requestBody  string
-		responseBody string
-	}{
-		{
-			name:         "ChatCompletions_ClientHeaders",
-			route:        routeChatCompletions,
-			requestBody:  `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
-			responseBody: chatCompletionResponse,
-		},
-		{
-			name:         "Responses_ClientHeaders",
-			route:        routeResponses,
-			requestBody:  `{"model": "gpt-5", "input": "hello", "stream": false}`,
-			responseBody: responsesAPIResponse,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			var receivedHeaders http.Header
-
-			mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				receivedHeaders = r.Header.Clone()
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, err := w.Write([]byte(tc.responseBody))
-				require.NoError(t, err)
-			}))
-			t.Cleanup(mockUpstream.Close)
-
-			provider := NewOpenAI(config.OpenAI{
-				BaseURL: mockUpstream.URL,
-				Key:     "test-key",
-			})
-
-			req := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, bytes.NewBufferString(tc.requestBody))
-			// No Authorization header: centralized mode. The configured provider key is used.
-			w := httptest.NewRecorder()
-
-			interceptor, err := provider.CreateInterceptor(w, req, testTracer)
-			require.NoError(t, err)
-			require.NotNil(t, interceptor)
-
-			logger := slog.Make()
-			interceptor.Setup(logger, &testutil.MockRecorder{}, nil)
-
-			processReq := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, nil)
-			err = interceptor.ProcessRequest(w, processReq)
-			require.NoError(t, err)
-
-			// Verify aibridge's configured key was used.
-			assert.Equal(t, "Bearer test-key", receivedHeaders.Get("Authorization"), "upstream must receive configured provider key")
-			assert.Empty(t, receivedHeaders.Get("X-Api-Key"), "X-Api-Key must not be set upstream")
-		})
-	}
-}
-
 func TestOpenAI_CreateInterceptor_BYOK(t *testing.T) {
 	t.Parallel()
 
@@ -307,6 +242,7 @@ func TestOpenAI_CreateInterceptor_BYOK(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.wantAuthorization, receivedHeaders.Get("Authorization"))
+			assert.Empty(t, receivedHeaders.Get("X-Api-Key"), "X-Api-Key must not be set upstream")
 		})
 	}
 }

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -184,7 +184,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			requestBody:       `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
 			responseBody:      chatCompletionResponse,
 			setHeaders:        map[string]string{},
-			wantAuthorization: "Bearer test-key",
+			wantAuthorization: "Bearer centralized-key",
 		},
 		{
 			name:              "Responses_BYOK_BearerToken",
@@ -200,7 +200,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			requestBody:       `{"model": "gpt-5", "input": "hello", "stream": false}`,
 			responseBody:      responsesAPIResponse,
 			setHeaders:        map[string]string{},
-			wantAuthorization: "Bearer test-key",
+			wantAuthorization: "Bearer centralized-key",
 		},
 	}
 
@@ -221,7 +221,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 
 			provider := NewOpenAI(config.OpenAI{
 				BaseURL: mockUpstream.URL,
-				Key:     "test-key",
+				Key:     "centralized-key",
 			})
 
 			req := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, bytes.NewBufferString(tc.requestBody))

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -159,7 +159,7 @@ func generateResponsesPayload(payloadSize int, inputCount int, stream bool) []by
 	return bodyBytes
 }
 
-func TestOpenAI_CreateInterceptor_BYOK(t *testing.T) {
+func TestOpenAI_CreateInterceptor(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/provider/openai_test.go
+++ b/provider/openai_test.go
@@ -203,9 +203,7 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			})
 
 			req := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, bytes.NewBufferString(tc.requestBody))
-			// Simulate a client sending its own auth credential, which must be replaced
-			// by aibridge with the configured provider key.
-			req.Header.Set("Authorization", "Bearer fake-client-bearer")
+			// No Authorization header: centralized mode. The configured provider key is used.
 			w := httptest.NewRecorder()
 
 			interceptor, err := provider.CreateInterceptor(w, req, testTracer)
@@ -219,9 +217,134 @@ func TestOpenAI_CreateInterceptor(t *testing.T) {
 			err = interceptor.ProcessRequest(w, processReq)
 			require.NoError(t, err)
 
-			// Verify aibridge's configured key was used and the client's auth credential was not forwarded.
+			// Verify aibridge's configured key was used.
 			assert.Equal(t, "Bearer test-key", receivedHeaders.Get("Authorization"), "upstream must receive configured provider key")
 			assert.Empty(t, receivedHeaders.Get("X-Api-Key"), "X-Api-Key must not be set upstream")
+		})
+	}
+}
+
+func TestOpenAI_CreateInterceptor_BYOK(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		route             string
+		requestBody       string
+		responseBody      string
+		setHeaders        map[string]string
+		wantAuthorization string
+	}{
+		{
+			name:              "ChatCompletions_BYOK_BearerToken",
+			route:             routeChatCompletions,
+			requestBody:       `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
+			responseBody:      chatCompletionResponse,
+			setHeaders:        map[string]string{"Authorization": "Bearer user-token"},
+			wantAuthorization: "Bearer user-token",
+		},
+		{
+			name:              "ChatCompletions_Centralized_UsesCentralizedKey",
+			route:             routeChatCompletions,
+			requestBody:       `{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}`,
+			responseBody:      chatCompletionResponse,
+			setHeaders:        map[string]string{},
+			wantAuthorization: "Bearer test-key",
+		},
+		{
+			name:              "Responses_BYOK_BearerToken",
+			route:             routeResponses,
+			requestBody:       `{"model": "gpt-5", "input": "hello", "stream": false}`,
+			responseBody:      responsesAPIResponse,
+			setHeaders:        map[string]string{"Authorization": "Bearer user-token"},
+			wantAuthorization: "Bearer user-token",
+		},
+		{
+			name:              "Responses_Centralized_UsesCentralizedKey",
+			route:             routeResponses,
+			requestBody:       `{"model": "gpt-5", "input": "hello", "stream": false}`,
+			responseBody:      responsesAPIResponse,
+			setHeaders:        map[string]string{},
+			wantAuthorization: "Bearer test-key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var receivedHeaders http.Header
+
+			mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHeaders = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte(tc.responseBody))
+				require.NoError(t, err)
+			}))
+			t.Cleanup(mockUpstream.Close)
+
+			provider := NewOpenAI(config.OpenAI{
+				BaseURL: mockUpstream.URL,
+				Key:     "test-key",
+			})
+
+			req := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, bytes.NewBufferString(tc.requestBody))
+			for k, v := range tc.setHeaders {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+
+			interceptor, err := provider.CreateInterceptor(w, req, testTracer)
+			require.NoError(t, err)
+			require.NotNil(t, interceptor)
+
+			logger := slog.Make()
+			interceptor.Setup(logger, &testutil.MockRecorder{}, nil)
+
+			processReq := httptest.NewRequest(http.MethodPost, provider.RoutePrefix()+tc.route, nil)
+			err = interceptor.ProcessRequest(w, processReq)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantAuthorization, receivedHeaders.Get("Authorization"))
+		})
+	}
+}
+
+func TestOpenAI_InjectAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	provider := NewOpenAI(config.OpenAI{Key: "centralized-key"})
+
+	tests := []struct {
+		name              string
+		presetHeaders     map[string]string
+		wantAuthorization string
+	}{
+		{
+			name:              "when no Authorization header is provided, inject centralized key",
+			presetHeaders:     map[string]string{},
+			wantAuthorization: "Bearer centralized-key",
+		},
+		{
+			name:              "when Authorization header is provided, do not overwrite it",
+			presetHeaders:     map[string]string{"Authorization": "Bearer user-token"},
+			wantAuthorization: "Bearer user-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			headers := http.Header{}
+			for k, v := range tc.presetHeaders {
+				headers.Set(k, v)
+			}
+
+			provider.InjectAuthHeader(&headers)
+
+			assert.Equal(t, tc.wantAuthorization, headers.Get("Authorization"))
 		})
 	}
 }


### PR DESCRIPTION
   ### Overview
   
`CreateInterceptor` detects user LLM credentials from request headers and sets them on the config copy. `InjectAuthHeader` skips centralized key injection when user credentials are already present (passthrough BYOK).                                                           
                                                                                                                                                      
  ### End-to-end flow                                                                                                              
                                                                                                                                                      
  **Centralized:** No user credentials in the request → centralized key is used.                                                            
   
  **BYOK (personal api key):** User's credential set in `Authorization`, `CreateInterceptor` detects it and replaces the centralized key with it.                                                                                     
                                                                                                                                                      
  ~~**ChatGPT subscription (Plus/Pro):** Same as BYOK (personal api key) but `Chatgpt-Account-Id` triggers routing to `chatgpt.com/backend-api/codex` instead of `api.openai.com/v1`, since subscription OAuth tokens are only accepted by the ChatGPT-specific backend.~~
                                                                   
   ### Related PRs                                                                                                                                                                                                                           
  Mirrors the Anthropic BYOK implementation from #216.