### PR TITLE
chore: capture prompts from haiku models

### DIFF
--- a/fixtures/anthropic/haiku_simple.txtar
+++ b/fixtures/anthropic/haiku_simple.txtar
@@ -1,0 +1,69 @@
+Simple request using a Haiku model (small/fast model).
+Used to validate that prompts are captured for small/fast models like Haiku,
+which Claude Code uses for ancillary tasks (e.g. generating session titles,
+push notification summaries).
+
+-- request --
+{
+  "max_tokens": 256,
+  "messages": [
+    {
+      "content": [
+        {
+          "text": "Chat title: yo\n\nAgent's last message:\nyo, what's up? How can I help?",
+          "type": "text"
+        }
+      ],
+      "role": "user"
+    }
+  ],
+  "model": "claude-haiku-4-5",
+  "system": [
+    {
+      "text": "You are a notification assistant. Given a chat title and the agent's last message, write a single short sentence summarizing what the agent did.",
+      "type": "text"
+    }
+  ]
+}
+
+-- streaming --
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01HaikuTest","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":42,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The agent greeted the user and offered help."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+-- non-streaming --
+{
+  "id": "msg_01HaikuTest",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-haiku-4-5-20251001",
+  "content": [
+    {
+      "type": "text",
+      "text": "The agent greeted the user and offered help."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 42,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "output_tokens": 12,
+    "service_tier": "standard"
+  }
+}

--- a/fixtures/anthropic/haiku_simple.txtar
+++ b/fixtures/anthropic/haiku_simple.txtar
@@ -5,65 +5,151 @@ push notification summaries).
 
 -- request --
 {
-  "max_tokens": 256,
+  "max_tokens": 8192,
   "messages": [
     {
+      "role": "user",
       "content": [
         {
-          "text": "Chat title: yo\n\nAgent's last message:\nyo, what's up? How can I help?",
-          "type": "text"
+          "type": "text",
+          "text": "how many angels can dance on the head of a pin\n"
         }
-      ],
-      "role": "user"
+      ]
     }
   ],
   "model": "claude-haiku-4-5",
-  "system": [
-    {
-      "text": "You are a notification assistant. Given a chat title and the agent's last message, write a single short sentence summarizing what the agent did.",
-      "type": "text"
-    }
-  ]
+  "temperature": 1
 }
 
 -- streaming --
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_01HaikuTest","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":42,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}}
+data: {"type":"message_start","message":{"id":"msg_01Pvyf26bY17RcjmWfJsXGBn","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":18,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}       }
 
 event: content_block_start
-data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
 
 event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The agent greeted the user and offered help."}}
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"This is a classic philosophical question about medieval scholasticism. I'll give a thoughtful answer."}}
 
 event: content_block_stop
 data: {"type":"content_block_stop","index":0}
 
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}  }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"This"} }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" is a famous philosophical question often used to illustrate medieval"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" scholastic debates that seem pointless or ov"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"erly abstract. The question \"How many angels can dance on the head of"}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" a pin?\" is typically cited as an example of us"}              }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"eless speculation.\n\nHistorically, medieval theolog"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"ians did debate the nature of angels -"}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" whether they were incorporeal beings, how"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" they occupied space, and whether multiple angels could exist"}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" in the same location. However, there"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"'s little evidence they literally"}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" debated dancing angels on pinheads.\n\nThe question has"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" no factual answer since it depends on assumptions about:"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"\n- The existence and nature of angels\n- Whether"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" incorporeal beings occupy physical space\n- What"}   }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" constitutes \"dancing\" for a spiritual"}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" entity\n- The size of both the"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" pin and the angels\n\nIt's become a metaph"}         }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"or for overthinking trivial matters"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" or getting lost in theoretical discussions disconnected from practical reality."}   }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" Some use it to critique certain types of academic"}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" or theological debate, while others defen"}   }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"d the value of exploring fundamental questions about existence an"}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"d metaphysics.\n\nSo while u"}               }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"nanswerable literally, it serves as an interesting lens"}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" for discussing the nature of philosophical inquiry itself."}       }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1  }
+
 event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}}
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":240}     }
 
 event: message_stop
-data: {"type":"message_stop"}
+data: {"type":"message_stop"            }
 
 -- non-streaming --
 {
-  "id": "msg_01HaikuTest",
+  "id": "msg_01Pvyf26bY17RcjmWfJsXGBn",
   "type": "message",
   "role": "assistant",
   "model": "claude-haiku-4-5-20251001",
   "content": [
     {
+      "type": "thinking",
+      "thinking": "This is a classic philosophical question about medieval scholasticism. I'll give a thoughtful answer."
+    },
+    {
       "type": "text",
-      "text": "The agent greeted the user and offered help."
+      "text": "This is a famous philosophical question, often called \"How many angels can dance on the head of a pin?\" It's typically used to represent pointless or overly abstract theological debates.\n\nThe question doesn't have a literal answer because:\n\n1. **Historical context**: It's often attributed to medieval scholastic philosophers, though there's little evidence they actually debated this exact question. It became a popular way to mock what some saw as useless academic arguments.\n\n2. **Philosophical purpose**: The question highlights the difficulty of discussing non-physical beings (angels) in physical terms (space on a pinhead).\n\n3. **Different interpretations**: \n   - If angels are purely spiritual, they might not take up physical space at all\n   - If they do occupy space, we'd need to know their \"size\"\n   - The question might be asking about the nature of space, matter, and spirit\n\nSo the real answer is that it's not meant to be answered literally - it's a thought experiment about the limits of rational inquiry and the sometimes absurd directions theological speculation can take.\n\nWould you like to explore the philosophical implications behind this question, or were you thinking about it in a different context?"
     }
   ],
   "stop_reason": "end_turn",
   "stop_sequence": null,
   "usage": {
-    "input_tokens": 42,
+    "input_tokens": 18,
     "cache_creation_input_tokens": 0,
     "cache_read_input_tokens": 0,
-    "output_tokens": 12,
+    "output_tokens": 254,
     "service_tier": "standard"
   }
 }

--- a/fixtures/fixtures.go
+++ b/fixtures/fixtures.go
@@ -35,6 +35,9 @@ var (
 
 	//go:embed anthropic/simple_bedrock.txtar
 	AntSimpleBedrock []byte
+
+	//go:embed anthropic/haiku_simple.txtar
+	AntHaikuSimple []byte
 )
 
 var (

--- a/intercept/messages/blocking.go
+++ b/intercept/messages/blocking.go
@@ -71,13 +71,11 @@ func (i *BlockingInterception) ProcessRequest(w http.ResponseWriter, r *http.Req
 	i.injectTools()
 
 	var prompt *string
-	if !i.isSmallFastModel() {
-		promptText, promptFound, promptErr := i.reqPayload.lastUserPrompt()
-		if promptErr != nil {
-			i.logger.Warn(ctx, "failed to retrieve last user prompt", slog.Error(promptErr))
-		} else if promptFound {
-			prompt = &promptText
-		}
+	promptText, promptFound, promptErr := i.reqPayload.lastUserPrompt()
+	if promptErr != nil {
+		i.logger.Warn(ctx, "failed to retrieve last user prompt", slog.Error(promptErr))
+	} else if promptFound {
+		prompt = &promptText
 	}
 
 	// TODO(ssncferreira): inject actor headers directly in the client-header

--- a/intercept/messages/streaming.go
+++ b/intercept/messages/streaming.go
@@ -106,13 +106,13 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 		err         error
 	)
 
+	prompt, promptFound, err = i.reqPayload.lastUserPrompt()
+	if err != nil {
+		logger.Warn(ctx, "failed to determine last user prompt", slog.Error(err))
+	}
+
 	// Claude Code uses a "small/fast model" for certain tasks.
 	if !i.isSmallFastModel() {
-		prompt, promptFound, err = i.reqPayload.lastUserPrompt()
-		if err != nil {
-			logger.Warn(ctx, "failed to determine last user prompt", slog.Error(err))
-		}
-
 		// Only inject tools into "actual" request.
 		i.injectTools()
 	}

--- a/internal/integrationtest/bridge_test.go
+++ b/internal/integrationtest/bridge_test.go
@@ -693,6 +693,17 @@ func TestSimple(t *testing.T) {
 			expectedClient:    aibridge.ClientClaudeCode,
 		},
 		{
+			name:              config.ProviderAnthropic + "_haiku_prompt_capture",
+			fixture:           fixtures.AntHaikuSimple,
+			basePath:          "",
+			expectedPath:      "/v1/messages",
+			getResponseIDFunc: getAnthropicResponseID,
+			path:              pathAnthropicMessages,
+			expectedMsgID:     "msg_01Pvyf26bY17RcjmWfJsXGBn",
+			userAgent:         "claude-cli/2.0.67 (external, cli)",
+			expectedClient:    aibridge.ClientClaudeCode,
+		},
+		{
 			name:              config.ProviderOpenAI,
 			fixture:           fixtures.OaiChatSimple,
 			basePath:          "",
@@ -2069,64 +2080,5 @@ func TestActorHeaders(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-// TestAnthropicMessagesHaikuPromptCapture validates that prompts are captured
-// for small/fast models like Haiku.
-//
-// Claude Code uses Haiku for ancillary tasks (generating session titles, push
-// notification summaries, etc.) and sets role:"user" on those requests even
-// though they are agent-initiated, not human-initiated. Previously we skipped
-// prompt capture for these models because, without the session view, it was
-// hard for auditors to reason about agent-initiated vs human-initiated prompts.
-// Now that the session view provides the broader context of how Haiku
-// interceptions relate to the parent session, we capture all prompts regardless
-// of model size so auditors have a complete picture.
-//
-// See: https://github.com/coder/aibridge/pull/230
-func TestAnthropicMessagesHaikuPromptCapture(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		streaming bool
-	}{
-		{name: "streaming", streaming: true},
-		{name: "non-streaming", streaming: false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
-			t.Cleanup(cancel)
-
-			fix := fixtures.Parse(t, fixtures.AntHaikuSimple)
-			upstream := newMockUpstream(t, ctx, newFixtureResponse(fix))
-
-			bridgeServer := newBridgeTestServer(t, ctx, upstream.URL)
-
-			reqBody, err := sjson.SetBytes(fix.Request(), "stream", tc.streaming)
-			require.NoError(t, err)
-			resp := bridgeServer.makeRequest(t, http.MethodPost, pathAnthropicMessages, reqBody)
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-
-			if tc.streaming {
-				sp := aibridge.NewSSEParser()
-				require.NoError(t, sp.Parse(resp.Body))
-				assert.Contains(t, sp.AllEvents(), "message_start")
-				assert.Contains(t, sp.AllEvents(), "message_stop")
-			}
-
-			// The key assertion: the prompt must be captured even though this is
-			// a Haiku (small/fast) model request.
-			promptUsages := bridgeServer.Recorder.RecordedPromptUsages()
-			require.Len(t, promptUsages, 1, "prompt should be captured for haiku models")
-			assert.Contains(t, promptUsages[0].Prompt, "Chat title: yo")
-
-			bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
-		})
 	}
 }

--- a/internal/integrationtest/bridge_test.go
+++ b/internal/integrationtest/bridge_test.go
@@ -2071,3 +2071,62 @@ func TestActorHeaders(t *testing.T) {
 		}
 	}
 }
+
+// TestAnthropicMessagesHaikuPromptCapture validates that prompts are captured
+// for small/fast models like Haiku.
+//
+// Claude Code uses Haiku for ancillary tasks (generating session titles, push
+// notification summaries, etc.) and sets role:"user" on those requests even
+// though they are agent-initiated, not human-initiated. Previously we skipped
+// prompt capture for these models because, without the session view, it was
+// hard for auditors to reason about agent-initiated vs human-initiated prompts.
+// Now that the session view provides the broader context of how Haiku
+// interceptions relate to the parent session, we capture all prompts regardless
+// of model size so auditors have a complete picture.
+//
+// See: https://github.com/coder/aibridge/pull/230
+func TestAnthropicMessagesHaikuPromptCapture(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		streaming bool
+	}{
+		{name: "streaming", streaming: true},
+		{name: "non-streaming", streaming: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+			t.Cleanup(cancel)
+
+			fix := fixtures.Parse(t, fixtures.AntHaikuSimple)
+			upstream := newMockUpstream(t, ctx, newFixtureResponse(fix))
+
+			bridgeServer := newBridgeTestServer(t, ctx, upstream.URL)
+
+			reqBody, err := sjson.SetBytes(fix.Request(), "stream", tc.streaming)
+			require.NoError(t, err)
+			resp := bridgeServer.makeRequest(t, http.MethodPost, pathAnthropicMessages, reqBody)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			if tc.streaming {
+				sp := aibridge.NewSSEParser()
+				require.NoError(t, sp.Parse(resp.Body))
+				assert.Contains(t, sp.AllEvents(), "message_start")
+				assert.Contains(t, sp.AllEvents(), "message_stop")
+			}
+
+			// The key assertion: the prompt must be captured even though this is
+			// a Haiku (small/fast) model request.
+			promptUsages := bridgeServer.Recorder.RecordedPromptUsages()
+			require.Len(t, promptUsages, 1, "prompt should be captured for haiku models")
+			assert.Contains(t, promptUsages[0].Prompt, "Chat title: yo")
+
+			bridgeServer.Recorder.VerifyAllInterceptionsEnded(t)
+		})
+	}
+}


### PR DESCRIPTION
**Context:**

When using Claude Code with Sonnet or Opus, it'll use the Haiku model for [ancillary actions](https://code.claude.com/docs/en/costs#background-token-usage) that don't require a lot of intelligence. Claude Code calls this model it's "small fast model".

When inference requests are sent, they include a "role" to discriminate between user- and assistant-initiated messages.

Here's an example of Claude Code generating a session title based on the initial human prompt.

<details>
<summary>Example request</summary>

```json
{
  "model": "claude-haiku-4-5-20251001",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "<system-reminder>\nAs you answer the user's questions, you can use the following context:..."
        },
        {
          "type": "text",
          "text": "Thoroughly explore the dbcrypt package in this codebase. I need to understand:\n\n1. What is dbcrypt and what problem does it solve?\n2. What is the architecture - key types, interfaces, and how they compose?\n3. How does encryption/decryption actually work (what cipher, what fields)?\n4. How is it integrated into the broader system (where is it instantiated, what wraps what)?\n5. Key files and their purposes\n6. How are encryption keys managed (rotation, active key, etc.)?\n\nSearch in enterprise/dbcrypt/ and also look for how it's used in coderd/ and enterprise/. Be very thorough - read the main files fully.",
          "cache_control": {
            "type": "ephemeral"
          }
        }
      ]
    }
  ],
  "system": [
    {
      "type": "text",
      "text": "You are Claude Code, Anthropic's official CLI for Claude.",
      "cache_control": {
        "type": "ephemeral"
      }
    },
    {
      "type": "text",
      "text": "You are a file search specialist for Claude Code, Anthropic's official CLI for Claude...",
      "cache_control": {
        "type": "ephemeral"
      }
    }
  ]
}
```

</details>

This request was initiated _by Claude Code_ not by the user; even so, Claude Code specifies `"role": "user"` which muddies the waters because now we can't know if this was actually initiated by a human or not.

---

When we were only displaying disconnected interceptions this was hard to reason about, so we decided to not capture the prompt for Haiku models. Now that we have the session view, however, it's much clearer how the Haiku models produce their prompts so auditors will be able to reason about it a little better. In this case, Claude Code is spawning an `Explore` agent to poke around the codebase.

<img width="1256" height="1104" alt="image" src="https://github.com/user-attachments/assets/576e468a-063f-40b2-8c84-418b51b2de5a" />

It's still suboptimal that we can't discriminate human- from agent-initiated prompts, but that's a problem with the source data which we can't currently work around.

_Aside: pity we didn't have tests validating the previous behaviour; that's on me._