### PR TITLE
feat: validate duplicate provider names in NewRequestBridge

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -57,6 +57,19 @@ type RequestBridge struct {
 
 var _ http.Handler = &RequestBridge{}
 
+// validateProviders checks that no two providers share the same name.
+func validateProviders(providers []provider.Provider) error {
+	names := make(map[string]bool, len(providers))
+	for _, prov := range providers {
+		if names[prov.Name()] {
+			return fmt.Errorf("duplicate provider name: %q", prov.Name())
+		}
+		names[prov.Name()] = true
+	}
+	// TODO(ssncferreira): validate duplicate baseURLs as well
+	return nil
+}
+
 // NewRequestBridge creates a new *[RequestBridge] and registers the HTTP routes defined by the given providers.
 // Any routes which are requested but not registered will be reverse-proxied to the upstream service.
 //
@@ -67,6 +80,10 @@ var _ http.Handler = &RequestBridge{}
 // Circuit breaker configuration is obtained from each provider's CircuitBreakerConfig() method.
 // Providers returning nil will not have circuit breaker protection.
 func NewRequestBridge(ctx context.Context, providers []provider.Provider, rec recorder.Recorder, mcpProxy mcp.ServerProxier, logger slog.Logger, m *metrics.Metrics, tracer trace.Tracer) (*RequestBridge, error) {
+	if err := validateProviders(providers); err != nil {
+		return nil, err
+	}
+
 	mux := http.NewServeMux()
 
 	for _, prov := range providers {

--- a/bridge.go
+++ b/bridge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -57,14 +58,21 @@ type RequestBridge struct {
 
 var _ http.Handler = &RequestBridge{}
 
-// validateProviders checks that no two providers share the same name.
+// validProviderName matches names containing only lowercase alphanumeric characters and hyphens.
+var validProviderName = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// validateProviders checks that provider names are valid and unique.
 func validateProviders(providers []provider.Provider) error {
 	names := make(map[string]bool, len(providers))
 	for _, prov := range providers {
-		if names[prov.Name()] {
-			return fmt.Errorf("duplicate provider name: %q", prov.Name())
+		name := prov.Name()
+		if !validProviderName.MatchString(name) {
+			return fmt.Errorf("invalid provider name %q: must contain only lowercase alphanumeric characters and hyphens", name)
 		}
-		names[prov.Name()] = true
+		if names[name] {
+			return fmt.Errorf("duplicate provider name: %q", name)
+		}
+		names[name] = true
 	}
 	return nil
 }

--- a/bridge.go
+++ b/bridge.go
@@ -66,7 +66,6 @@ func validateProviders(providers []provider.Provider) error {
 		}
 		names[prov.Name()] = true
 	}
-	// TODO(ssncferreira): validate duplicate baseURLs as well
 	return nil
 }
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateProviders(t *testing.T) {
+func TestValidateProvider_Names(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -48,12 +48,57 @@ func TestValidateProviders(t *testing.T) {
 			},
 		},
 		{
-			name: "duplicate_name",
+			name: "name_with_slashes",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "copilot/business", BaseURL: "https://api.business.githubcopilot.com"}),
+			},
+			expectErr: "invalid provider name",
+		},
+		{
+			name: "name_with_spaces",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "copilot business", BaseURL: "https://api.business.githubcopilot.com"}),
+			},
+			expectErr: "invalid provider name",
+		},
+		{
+			name: "name_with_uppercase",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "Copilot", BaseURL: "https://api.business.githubcopilot.com"}),
+			},
+			expectErr: "invalid provider name",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateProviders(tc.providers)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateProvider_DuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		providers []provider.Provider
+		expectErr string
+	}{
+		{
+			name: "unique_names",
 			providers: []provider.Provider{
 				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
-				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.business.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-business", BaseURL: "https://api.business.githubcopilot.com"}),
 			},
-			expectErr: "duplicate provider name",
 		},
 		{
 			name: "duplicate_base_url_different_names",
@@ -61,6 +106,14 @@ func TestValidateProviders(t *testing.T) {
 				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
 				NewCopilotProvider(config.Copilot{Name: "copilot-business", BaseURL: "https://api.individual.githubcopilot.com"}),
 			},
+		},
+		{
+			name: "duplicate_name",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.business.githubcopilot.com"}),
+			},
+			expectErr: "duplicate provider name",
 		},
 	}
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -13,6 +13,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateProviders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		providers []provider.Provider
+		expectErr string
+	}{
+		{
+			name: "all_supported_providers",
+			providers: []provider.Provider{
+				NewOpenAIProvider(config.OpenAI{Name: "openai", BaseURL: "https://api.openai.com/v1/"}),
+				NewAnthropicProvider(config.Anthropic{Name: "anthropic", BaseURL: "https://api.anthropic.com/"}, nil),
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-business", BaseURL: "https://api.business.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-enterprise", BaseURL: "https://api.enterprise.githubcopilot.com"}),
+			},
+		},
+		{
+			name: "default_names_and_base_urls",
+			providers: []provider.Provider{
+				NewOpenAIProvider(config.OpenAI{}),
+				NewAnthropicProvider(config.Anthropic{}, nil),
+				NewCopilotProvider(config.Copilot{}),
+			},
+		},
+		{
+			name: "multiple_copilot_instances",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-business", BaseURL: "https://api.business.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-enterprise", BaseURL: "https://api.enterprise.githubcopilot.com"}),
+			},
+		},
+		{
+			name: "duplicate_name",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.business.githubcopilot.com"}),
+			},
+			expectErr: "duplicate provider name",
+		},
+		{
+			name: "duplicate_base_url_different_names",
+			providers: []provider.Provider{
+				NewCopilotProvider(config.Copilot{Name: "copilot", BaseURL: "https://api.individual.githubcopilot.com"}),
+				NewCopilotProvider(config.Copilot{Name: "copilot-business", BaseURL: "https://api.individual.githubcopilot.com"}),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateProviders(tc.providers)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPassthroughRoutesForProviders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Adds validation to `NewRequestBridge` to prevent registering multiple providers with the same name. Duplicate names would cause route prefix conflicts and ambiguous metrics, logs, and circuit breaker behavior.

## Changes

* Add `validateProviders()` that rejects duplicate provider names at startup
* Add table-driven tests covering valid configurations and duplicate name detection

Related to: https://github.com/coder/aibridge/issues/152

_Disclaimer: initially produced by Claude Opus 4.6, heavily modified and reviewed by @ssncferreira ._