### PR TITLE
fix: handle Claude Code session detection for new header / metadata format

### DIFF
--- a/session.go
+++ b/session.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-var claudeCodePattern = regexp.MustCompile(`_session_(.+)$`) // Save compilation on each call.
+var claudeCodePattern = regexp.MustCompile(`_session_(.+)$`) // Legacy format: save compilation on each call.
 
 // guessSessionID attempts to retrieve a session ID which may have been sent by
 // the client. We only attempt to retrieve sessions using methods recognized for
@@ -20,12 +20,17 @@ func guessSessionID(client Client, r *http.Request) *string {
 	switch client {
 	case ClientClaudeCode:
 		/* Claude Code adds the session ID into the `metadata.user_id` field in the JSON body.
+		Legacy format:
 		{
-			...
 			"metadata": {
 				"user_id": "user_{sha256}_account_{account_id}_session_{uuid_v4}"
-			},
-			...
+			}
+		}
+		New format (the value is a JSON-encoded string):
+		{
+			"metadata": {
+				"user_id": "{\"device_id\":\"...\",\"account_uuid\":\"...\",\"session_id\":\"uuid_v4\"}"
+			}
 		} */
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -41,7 +46,15 @@ func guessSessionID(client Client, r *http.Request) *string {
 			return nil
 		}
 
-		matches := claudeCodePattern.FindStringSubmatch(userID.String())
+		raw := userID.String()
+
+		// New format: user_id is a JSON-encoded object with a session_id field.
+		if sessionID := gjson.Get(raw, "session_id"); sessionID.Exists() {
+			return cleanRef(sessionID.String())
+		}
+
+		// Legacy format: "user_{sha256}_account_{id}_session_{uuid}"
+		matches := claudeCodePattern.FindStringSubmatch(raw)
 		if len(matches) < 2 {
 			return nil
 		}

--- a/session.go
+++ b/session.go
@@ -19,22 +19,16 @@ var claudeCodePattern = regexp.MustCompile(`_session_(.+)$`) // Legacy format: s
 func guessSessionID(client Client, r *http.Request) *string {
 	switch client {
 	case ClientClaudeCode:
-		/* Claude Code adds the session ID into the `metadata.user_id` field in the JSON body.
-		Legacy format:
-		{
-			"metadata": {
-				"user_id": "user_{sha256}_account_{account_id}_session_{uuid_v4}"
-			}
+		// Prefer the dedicated header (added in Claude Code v2.1.86+).
+		if sid := cleanRef(r.Header.Get("X-Claude-Code-Session-Id")); sid != nil {
+			return sid
 		}
-		New format (the value is a JSON-encoded string):
-		{
-			"metadata": {
-				"user_id": "{\"device_id\":\"...\",\"account_uuid\":\"...\",\"session_id\":\"uuid_v4\"}"
-			}
-		} */
+
+		// Fall back to extracting from the metadata.user_id field in the JSON body.
+		// Legacy format: "user_{sha256}_account_{id}_session_{uuid}"
+		// Newer format:  JSON-encoded object with a "session_id" field.
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {
-			// Failing silently is suitable here; if the body cannot be read, we won't be able to do much more.
 			return nil
 		}
 		_ = r.Body.Close()
@@ -48,12 +42,12 @@ func guessSessionID(client Client, r *http.Request) *string {
 
 		raw := userID.String()
 
-		// New format: user_id is a JSON-encoded object with a session_id field.
+		// Newer body format: user_id is a JSON-encoded object with a session_id field.
 		if sessionID := gjson.Get(raw, "session_id"); sessionID.Exists() {
 			return cleanRef(sessionID.String())
 		}
 
-		// Legacy format: "user_{sha256}_account_{id}_session_{uuid}"
+		// Legacy body format: "user_{sha256}_account_{id}_session_{uuid}"
 		matches := claudeCodePattern.FindStringSubmatch(raw)
 		if len(matches) < 2 {
 			return nil

--- a/session.go
+++ b/session.go
@@ -25,8 +25,8 @@ func guessSessionID(client Client, r *http.Request) *string {
 		}
 
 		// Fall back to extracting from the metadata.user_id field in the JSON body.
-		// Legacy format: "user_{sha256}_account_{id}_session_{uuid}"
 		// Newer format:  JSON-encoded object with a "session_id" field.
+		// Legacy format: "user_{sha256}_account_{id}_session_{uuid}"
 		payload, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil
@@ -36,7 +36,7 @@ func guessSessionID(client Client, r *http.Request) *string {
 		// Restore the request body.
 		r.Body = io.NopCloser(bytes.NewReader(payload))
 		userID := gjson.GetBytes(payload, "metadata.user_id")
-		if !userID.Exists() {
+		if userID.Type != gjson.String {
 			return nil
 		}
 

--- a/session_test.go
+++ b/session_test.go
@@ -28,6 +28,22 @@ func TestGuessSessionID(t *testing.T) {
 			sessionID: utils.PtrTo("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
 		},
 		{
+			name:      "claude_code_with_valid_session_new_format",
+			client:    ClientClaudeCode,
+			body:      `{"metadata":{"user_id":"{\"device_id\":\"45aa15c8c244ea2582f8144dde91a50ec3815851f6f648abef4ee15b173cc927\",\"account_uuid\":\"\",\"session_id\":\"54c1eb09-bc4c-4d2f-98eb-6d2ab2d5e2fe\"}"}}`,
+			sessionID: utils.PtrTo("54c1eb09-bc4c-4d2f-98eb-6d2ab2d5e2fe"),
+		},
+		{
+			name:   "claude_code_new_format_empty_session_id",
+			client: ClientClaudeCode,
+			body:   `{"metadata":{"user_id":"{\"device_id\":\"abc\",\"account_uuid\":\"\",\"session_id\":\"\"}"}}`,
+		},
+		{
+			name:   "claude_code_new_format_no_session_id_field",
+			client: ClientClaudeCode,
+			body:   `{"metadata":{"user_id":"{\"device_id\":\"abc\",\"account_uuid\":\"\"}"}}`,
+		},
+		{
 			name:   "claude_code_missing_metadata",
 			client: ClientClaudeCode,
 			body:   `{"model":"claude-3"}`,

--- a/session_test.go
+++ b/session_test.go
@@ -43,6 +43,13 @@ func TestGuessSessionID(t *testing.T) {
 			sessionID: utils.PtrTo("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
 		},
 		{
+			name:      "claude_code_whitespace_header_falls_back_to_body",
+			client:    ClientClaudeCode,
+			headers:   map[string]string{"X-Claude-Code-Session-Id": "   "},
+			body:      `{"metadata":{"user_id":"user_abc123_account_456_session_f47ac10b-58cc-4372-a567-0e02b2c3d479"}}`,
+			sessionID: utils.PtrTo("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+		},
+		{
 			name:      "claude_code_with_valid_session",
 			client:    ClientClaudeCode,
 			body:      `{"metadata":{"user_id":"user_abc123_account_456_session_f47ac10b-58cc-4372-a567-0e02b2c3d479"}}`,

--- a/session_test.go
+++ b/session_test.go
@@ -22,6 +22,27 @@ func TestGuessSessionID(t *testing.T) {
 	}{
 		// Claude Code.
 		{
+			name:      "claude_code_header_takes_precedence",
+			client:    ClientClaudeCode,
+			headers:   map[string]string{"X-Claude-Code-Session-Id": "header-session-id"},
+			body:      `{"metadata":{"user_id":"user_abc123_account_456_session_body-session-id"}}`,
+			sessionID: utils.PtrTo("header-session-id"),
+		},
+		{
+			name:      "claude_code_header_only",
+			client:    ClientClaudeCode,
+			headers:   map[string]string{"X-Claude-Code-Session-Id": "aabb-ccdd"},
+			body:      `{"model":"claude-3"}`,
+			sessionID: utils.PtrTo("aabb-ccdd"),
+		},
+		{
+			name:      "claude_code_empty_header_falls_back_to_body",
+			client:    ClientClaudeCode,
+			headers:   map[string]string{"X-Claude-Code-Session-Id": ""},
+			body:      `{"metadata":{"user_id":"user_abc123_account_456_session_f47ac10b-58cc-4372-a567-0e02b2c3d479"}}`,
+			sessionID: utils.PtrTo("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+		},
+		{
 			name:      "claude_code_with_valid_session",
 			client:    ClientClaudeCode,
 			body:      `{"metadata":{"user_id":"user_abc123_account_456_session_f47ac10b-58cc-4372-a567-0e02b2c3d479"}}`,


### PR DESCRIPTION
Claude Code changed this metadata format (from which we extract the session ID):

before:

```json
...
  "metadata": {
    "user_id": "user_..._account__session_57a121ec-f78c-48c3-a745-e3036a3ecc33"
  },
...
```

after:

```json
...
  "metadata": {
    "user_id": "{\"device_id\":\"...\",\"account_uuid\":\"\",\"session_id\":\"54c1eb09-bc4c-4d2f-98eb-6d2ab2d5e2fe\"}"
  },
...
```

To make matters even more complicated, from v2.1.86 it introduced as `X-Claude-Code-Session-Id` header.

This PR supports all 3 approaches.