### PR TITLE
chore: add support for Coder Agents sessions

### DIFF
--- a/session.go
+++ b/session.go
@@ -66,7 +66,7 @@ func guessSessionID(client Client, r *http.Request) *string {
 	case ClientKilo:
 		return cleanRef(r.Header.Get("X-KILOCODE-TASKID"))
 	case ClientCoderAgents:
-		return nil // Session ID support planned in a follow-up.
+		return cleanRef(r.Header.Get("X-Coder-Chat-Id"))
 	case ClientRoo:
 		return nil // RooCode doesn't send a session ID.
 	case ClientCursor:

--- a/session_test.go
+++ b/session_test.go
@@ -127,7 +127,13 @@ func TestGuessSessionID(t *testing.T) {
 		},
 		// Coder Agents.
 		{
-			name:   "coder_agents_returns_empty",
+			name:      "coder_agents_with_chat_id",
+			client:    ClientCoderAgents,
+			headers:   map[string]string{"X-Coder-Chat-Id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+			sessionID: utils.PtrTo("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+		},
+		{
+			name:   "coder_agents_without_chat_id",
 			client: ClientCoderAgents,
 		},
 		// Roo.


### PR DESCRIPTION
_Disclaimer:_ _implemented_ _using_ _Claude_ _Opus_ _4\.6, reviewed by me._

Follow-up from https://github.com/coder/coder/pull/23578

We still need to fake the initiator using the `X-Coder-Owner-Id`; that's implemented upstack.
Validated manually using Coder Agents with an OpenAI-Compatible provider pointed at AI Bridge in my workspace.