### PR TITLE
chore: lint fixes part 3

### DIFF
--- a/intercept/apidump/apidump.go
+++ b/intercept/apidump/apidump.go
@@ -153,7 +153,7 @@ func (d *dumper) dumpResponse(resp *http.Response) error {
 // for deterministic output.
 // `sensitive` and `overrides` must both supply keys in canoncialized form.
 // See [textproto.MIMEHeader].
-func (d *dumper) writeRedactedHeaders(w io.Writer, headers http.Header, sensitive map[string]struct{}, overrides map[string]string) error {
+func (*dumper) writeRedactedHeaders(w io.Writer, headers http.Header, sensitive map[string]struct{}, overrides map[string]string) error {
 	// Collect all header keys including overrides.
 	headerKeys := make([]string, 0, len(headers)+len(overrides))
 	seen := make(map[string]struct{}, len(headers)+len(overrides))

--- a/intercept/chatcompletions/base.go
+++ b/intercept/chatcompletions/base.go
@@ -99,13 +99,13 @@ func (i *interceptionBase) CorrelatingToolCallID() *string {
 	return &msg.OfTool.ToolCallID
 }
 
-func (s *interceptionBase) baseTraceAttributes(r *http.Request, streaming bool) []attribute.KeyValue {
+func (i *interceptionBase) baseTraceAttributes(r *http.Request, streaming bool) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String(tracing.RequestPath, r.URL.Path),
-		attribute.String(tracing.InterceptionID, s.id.String()),
+		attribute.String(tracing.InterceptionID, i.id.String()),
 		attribute.String(tracing.InitiatorID, aibcontext.ActorIDFromContext(r.Context())),
-		attribute.String(tracing.Provider, s.providerName),
-		attribute.String(tracing.Model, s.Model()),
+		attribute.String(tracing.Provider, i.providerName),
+		attribute.String(tracing.Model, i.Model()),
 		attribute.Bool(tracing.Streaming, streaming),
 	}
 }
@@ -118,7 +118,7 @@ func (i *interceptionBase) Model() string {
 	return i.req.Model
 }
 
-func (i *interceptionBase) newErrorResponse(err error) map[string]any {
+func (*interceptionBase) newErrorResponse(err error) map[string]any {
 	return map[string]any{
 		"error":   true,
 		"message": err.Error(),

--- a/intercept/chatcompletions/blocking.go
+++ b/intercept/chatcompletions/blocking.go
@@ -51,16 +51,16 @@ func NewBlockingInterceptor(
 	}}
 }
 
-func (s *BlockingInterception) Setup(logger slog.Logger, recorder recorder.Recorder, mcpProxy mcp.ServerProxier) {
-	s.interceptionBase.Setup(logger.Named("blocking"), recorder, mcpProxy)
+func (i *BlockingInterception) Setup(logger slog.Logger, recorder recorder.Recorder, mcpProxy mcp.ServerProxier) {
+	i.interceptionBase.Setup(logger.Named("blocking"), recorder, mcpProxy)
 }
 
-func (s *BlockingInterception) Streaming() bool {
+func (*BlockingInterception) Streaming() bool {
 	return false
 }
 
-func (s *BlockingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
-	return s.interceptionBase.baseTraceAttributes(r, false)
+func (i *BlockingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
+	return i.interceptionBase.baseTraceAttributes(r, false)
 }
 
 func (i *BlockingInterception) ProcessRequest(w http.ResponseWriter, r *http.Request) (outErr error) {

--- a/intercept/chatcompletions/streaming.go
+++ b/intercept/chatcompletions/streaming.go
@@ -59,12 +59,12 @@ func (i *StreamingInterception) Setup(logger slog.Logger, recorder recorder.Reco
 	i.interceptionBase.Setup(logger.Named("streaming"), recorder, mcpProxy)
 }
 
-func (i *StreamingInterception) Streaming() bool {
+func (*StreamingInterception) Streaming() bool {
 	return true
 }
 
-func (s *StreamingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
-	return s.interceptionBase.baseTraceAttributes(r, true)
+func (i *StreamingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
+	return i.interceptionBase.baseTraceAttributes(r, true)
 }
 
 // ProcessRequest handles a request to /v1/chat/completions.
@@ -389,7 +389,7 @@ func (i *StreamingInterception) marshalErr(err error) ([]byte, error) {
 	return i.encodeForStream(data), nil
 }
 
-func (i *StreamingInterception) encodeForStream(payload []byte) []byte {
+func (*StreamingInterception) encodeForStream(payload []byte) []byte {
 	var buf bytes.Buffer
 	buf.WriteString("data: ")
 	buf.Write(payload)

--- a/intercept/eventstream/eventstream.go
+++ b/intercept/eventstream/eventstream.go
@@ -32,7 +32,6 @@ type EventStream struct {
 	initiated    atomic.Bool
 	initiateOnce sync.Once
 
-	closeOnce    sync.Once
 	shutdownOnce sync.Once
 	eventsCh     chan event
 

--- a/intercept/messages/base.go
+++ b/intercept/messages/base.go
@@ -118,15 +118,15 @@ func (i *interceptionBase) Model() string {
 	return i.reqPayload.model()
 }
 
-func (s *interceptionBase) baseTraceAttributes(r *http.Request, streaming bool) []attribute.KeyValue {
+func (i *interceptionBase) baseTraceAttributes(r *http.Request, streaming bool) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String(tracing.RequestPath, r.URL.Path),
-		attribute.String(tracing.InterceptionID, s.id.String()),
+		attribute.String(tracing.InterceptionID, i.id.String()),
 		attribute.String(tracing.InitiatorID, aibcontext.ActorIDFromContext(r.Context())),
-		attribute.String(tracing.Provider, s.providerName),
-		attribute.String(tracing.Model, s.Model()),
+		attribute.String(tracing.Provider, i.providerName),
+		attribute.String(tracing.Model, i.Model()),
 		attribute.Bool(tracing.Streaming, streaming),
-		attribute.Bool(tracing.IsBedrock, s.bedrockCfg != nil),
+		attribute.Bool(tracing.IsBedrock, i.bedrockCfg != nil),
 	}
 }
 
@@ -176,7 +176,7 @@ func (i *interceptionBase) disableParallelToolCalls() {
 }
 
 // extractModelThoughts returns any thinking blocks that were returned in the response.
-func (i *interceptionBase) extractModelThoughts(msg *anthropic.Message) []*recorder.ModelThoughtRecord {
+func (*interceptionBase) extractModelThoughts(msg *anthropic.Message) []*recorder.ModelThoughtRecord {
 	if msg == nil {
 		return nil
 	}
@@ -264,7 +264,7 @@ func (i *interceptionBase) withBody() option.RequestOption {
 	return option.WithRequestBody("application/json", []byte(i.reqPayload))
 }
 
-func (i *interceptionBase) withAWSBedrockOptions(ctx context.Context, cfg *aibconfig.AWSBedrock) ([]option.RequestOption, error) {
+func (*interceptionBase) withAWSBedrockOptions(ctx context.Context, cfg *aibconfig.AWSBedrock) ([]option.RequestOption, error) {
 	if cfg == nil {
 		return nil, xerrors.New("nil config given")
 	}

--- a/intercept/messages/base_test.go
+++ b/intercept/messages/base_test.go
@@ -777,11 +777,11 @@ type mockServerProxier struct {
 	tools []*mcp.Tool
 }
 
-func (m *mockServerProxier) Init(context.Context) error {
+func (*mockServerProxier) Init(context.Context) error {
 	return nil
 }
 
-func (m *mockServerProxier) Shutdown(context.Context) error {
+func (*mockServerProxier) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -798,7 +798,7 @@ func (m *mockServerProxier) GetTool(id string) *mcp.Tool {
 	return nil
 }
 
-func (m *mockServerProxier) CallTool(context.Context, string, any) (*mcpgo.CallToolResult, error) {
+func (*mockServerProxier) CallTool(context.Context, string, any) (*mcpgo.CallToolResult, error) {
 	return nil, nil
 }
 

--- a/intercept/messages/blocking.go
+++ b/intercept/messages/blocking.go
@@ -62,7 +62,7 @@ func (i *BlockingInterception) TraceAttributes(r *http.Request) []attribute.KeyV
 	return i.interceptionBase.baseTraceAttributes(r, false)
 }
 
-func (s *BlockingInterception) Streaming() bool {
+func (*BlockingInterception) Streaming() bool {
 	return false
 }
 

--- a/intercept/messages/reqpayload.go
+++ b/intercept/messages/reqpayload.go
@@ -313,7 +313,7 @@ func (p MessagesRequestPayload) tools() ([]json.RawMessage, error) {
 	return p.resultToRawMessage(tools.Array()), nil
 }
 
-func (p MessagesRequestPayload) resultToRawMessage(items []gjson.Result) []json.RawMessage {
+func (MessagesRequestPayload) resultToRawMessage(items []gjson.Result) []json.RawMessage {
 	// gjson.Result conversion to json.RawMessage is needed because
 	// gjson.Result does not implement json.Marshaler — would
 	// serialize its struct fields instead of the raw JSON it represents.

--- a/intercept/messages/streaming.go
+++ b/intercept/messages/streaming.go
@@ -59,16 +59,16 @@ func NewStreamingInterceptor(
 	}}
 }
 
-func (s *StreamingInterception) Setup(logger slog.Logger, recorder recorder.Recorder, mcpProxy mcp.ServerProxier) {
-	s.interceptionBase.Setup(logger.Named("streaming"), recorder, mcpProxy)
+func (i *StreamingInterception) Setup(logger slog.Logger, recorder recorder.Recorder, mcpProxy mcp.ServerProxier) {
+	i.interceptionBase.Setup(logger.Named("streaming"), recorder, mcpProxy)
 }
 
-func (s *StreamingInterception) Streaming() bool {
+func (*StreamingInterception) Streaming() bool {
 	return true
 }
 
-func (s *StreamingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
-	return s.interceptionBase.baseTraceAttributes(r, true)
+func (i *StreamingInterception) TraceAttributes(r *http.Request) []attribute.KeyValue {
+	return i.interceptionBase.baseTraceAttributes(r, true)
 }
 
 // ProcessRequest handles a request to /v1/messages.
@@ -534,8 +534,8 @@ newStream:
 	return interceptionErr
 }
 
-func (s *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventUnion) ([]byte, error) {
-	sj, err := sjson.Set(event.RawJSON(), "message.id", s.ID().String())
+func (i *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventUnion) ([]byte, error) {
+	sj, err := sjson.Set(event.RawJSON(), "message.id", i.ID().String())
 	if err != nil {
 		return nil, xerrors.Errorf("marshal event id failed: %w", err)
 	}
@@ -545,10 +545,10 @@ func (s *StreamingInterception) marshalEvent(event anthropic.MessageStreamEventU
 		return nil, xerrors.Errorf("marshal event usage failed: %w", err)
 	}
 
-	return s.encodeForStream([]byte(sj), event.Type), nil
+	return i.encodeForStream([]byte(sj), event.Type), nil
 }
 
-func (s *StreamingInterception) marshal(payload any) ([]byte, error) {
+func (i *StreamingInterception) marshal(payload any) ([]byte, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, xerrors.Errorf("marshal payload: %w", err)
@@ -564,15 +564,15 @@ func (s *StreamingInterception) marshal(payload any) ([]byte, error) {
 		return nil, xerrors.Errorf("could not determine type from payload %q", data)
 	}
 
-	return s.encodeForStream(data, eventType), nil
+	return i.encodeForStream(data, eventType), nil
 }
 
 // https://docs.anthropic.com/en/docs/build-with-claude/streaming#basic-streaming-request
-func (s *StreamingInterception) pingPayload() []byte {
-	return s.encodeForStream([]byte(`{"type": "ping"}`), "ping")
+func (i *StreamingInterception) pingPayload() []byte {
+	return i.encodeForStream([]byte(`{"type": "ping"}`), "ping")
 }
 
-func (s *StreamingInterception) encodeForStream(payload []byte, typ string) []byte {
+func (*StreamingInterception) encodeForStream(payload []byte, typ string) []byte {
 	var buf bytes.Buffer
 	buf.WriteString("event: ")
 	buf.WriteString(typ)
@@ -584,9 +584,9 @@ func (s *StreamingInterception) encodeForStream(payload []byte, typ string) []by
 }
 
 // newStream traces svc.NewStreaming() call.
-func (s *StreamingInterception) newStream(ctx context.Context, svc anthropic.MessageService) *ssestream.Stream[anthropic.MessageStreamEventUnion] {
-	_, span := s.tracer.Start(ctx, "Intercept.ProcessRequest.Upstream", trace.WithAttributes(tracing.InterceptionAttributesFromContext(ctx)...))
+func (i *StreamingInterception) newStream(ctx context.Context, svc anthropic.MessageService) *ssestream.Stream[anthropic.MessageStreamEventUnion] {
+	_, span := i.tracer.Start(ctx, "Intercept.ProcessRequest.Upstream", trace.WithAttributes(tracing.InterceptionAttributesFromContext(ctx)...))
 	defer span.End()
 
-	return svc.NewStreaming(ctx, anthropic.MessageNewParams{}, s.withBody())
+	return svc.NewStreaming(ctx, anthropic.MessageNewParams{}, i.withBody())
 }

--- a/intercept/responses/base.go
+++ b/intercept/responses/base.go
@@ -264,7 +264,7 @@ func (i *responsesInterceptionBase) recordTokenUsage(ctx context.Context, respon
 // extractModelThoughts extracts model thoughts from response output items.
 // It captures both reasoning summary items and commentary messages (message
 // output items with "phase": "commentary") as model thoughts.
-func (i *responsesInterceptionBase) extractModelThoughts(response *responses.Response) []*recorder.ModelThoughtRecord {
+func (*responsesInterceptionBase) extractModelThoughts(response *responses.Response) []*recorder.ModelThoughtRecord {
 	if response == nil {
 		return nil
 	}

--- a/intercept/responses/blocking.go
+++ b/intercept/responses/blocking.go
@@ -54,7 +54,7 @@ func (i *BlockingResponsesInterceptor) Setup(logger slog.Logger, recorder record
 	i.responsesInterceptionBase.Setup(logger.Named("blocking"), recorder, mcpProxy)
 }
 
-func (i *BlockingResponsesInterceptor) Streaming() bool {
+func (*BlockingResponsesInterceptor) Streaming() bool {
 	return false
 }
 

--- a/intercept/responses/streaming.go
+++ b/intercept/responses/streaming.go
@@ -61,7 +61,7 @@ func (i *StreamingResponsesInterceptor) Setup(logger slog.Logger, recorder recor
 	i.responsesInterceptionBase.Setup(logger.Named("streaming"), recorder, mcpProxy)
 }
 
-func (i *StreamingResponsesInterceptor) Streaming() bool {
+func (*StreamingResponsesInterceptor) Streaming() bool {
 	return true
 }
 

--- a/internal/integrationtest/mockmcp.go
+++ b/internal/integrationtest/mockmcp.go
@@ -141,7 +141,7 @@ func createMockMCPSrv(t *testing.T) (http.Handler, *callAccumulator) {
 		tool := mcplib.NewTool(name,
 			mcplib.WithDescription(fmt.Sprintf("Mock of the %s tool", name)),
 		)
-		s.AddTool(tool, func(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+		s.AddTool(tool, func(_ context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
 			acc.addCall(request.Params.Name, request.Params.Arguments)
 			if errMsg, ok := acc.getToolError(request.Params.Name); ok {
 				return nil, xerrors.New(errMsg)

--- a/internal/testutil/mock_recorder.go
+++ b/internal/testutil/mock_recorder.go
@@ -26,14 +26,14 @@ type MockRecorder struct {
 	interceptionsEnd map[string]*recorder.InterceptionRecordEnded
 }
 
-func (m *MockRecorder) RecordInterception(ctx context.Context, req *recorder.InterceptionRecord) error {
+func (m *MockRecorder) RecordInterception(_ context.Context, req *recorder.InterceptionRecord) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.interceptions = append(m.interceptions, req)
 	return nil
 }
 
-func (m *MockRecorder) RecordInterceptionEnded(ctx context.Context, req *recorder.InterceptionRecordEnded) error {
+func (m *MockRecorder) RecordInterceptionEnded(_ context.Context, req *recorder.InterceptionRecordEnded) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.interceptionsEnd == nil {
@@ -46,28 +46,28 @@ func (m *MockRecorder) RecordInterceptionEnded(ctx context.Context, req *recorde
 	return nil
 }
 
-func (m *MockRecorder) RecordPromptUsage(ctx context.Context, req *recorder.PromptUsageRecord) error {
+func (m *MockRecorder) RecordPromptUsage(_ context.Context, req *recorder.PromptUsageRecord) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.userPrompts = append(m.userPrompts, req)
 	return nil
 }
 
-func (m *MockRecorder) RecordTokenUsage(ctx context.Context, req *recorder.TokenUsageRecord) error {
+func (m *MockRecorder) RecordTokenUsage(_ context.Context, req *recorder.TokenUsageRecord) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.tokenUsages = append(m.tokenUsages, req)
 	return nil
 }
 
-func (m *MockRecorder) RecordToolUsage(ctx context.Context, req *recorder.ToolUsageRecord) error {
+func (m *MockRecorder) RecordToolUsage(_ context.Context, req *recorder.ToolUsageRecord) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.toolUsages = append(m.toolUsages, req)
 	return nil
 }
 
-func (m *MockRecorder) RecordModelThought(ctx context.Context, req *recorder.ModelThoughtRecord) error {
+func (m *MockRecorder) RecordModelThought(_ context.Context, req *recorder.ModelThoughtRecord) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.modelThoughts = append(m.modelThoughts, req)

--- a/internal/testutil/mockprovider.go
+++ b/internal/testutil/mockprovider.go
@@ -18,16 +18,16 @@ type MockProvider struct {
 	InterceptorFunc func(w http.ResponseWriter, r *http.Request, tracer trace.Tracer) (intercept.Interceptor, error)
 }
 
-func (m *MockProvider) Type() string                                 { return m.NameStr }
-func (m *MockProvider) Name() string                                 { return m.NameStr }
-func (m *MockProvider) BaseURL() string                              { return m.URL }
-func (m *MockProvider) RoutePrefix() string                          { return fmt.Sprintf("/%s", m.NameStr) }
-func (m *MockProvider) BridgedRoutes() []string                      { return m.Bridged }
-func (m *MockProvider) PassthroughRoutes() []string                  { return m.Passthrough }
-func (m *MockProvider) AuthHeader() string                           { return "Authorization" }
-func (m *MockProvider) InjectAuthHeader(h *http.Header)              {}
-func (m *MockProvider) CircuitBreakerConfig() *config.CircuitBreaker { return nil }
-func (m *MockProvider) APIDumpDir() string                           { return "" }
+func (m *MockProvider) Type() string                               { return m.NameStr }
+func (m *MockProvider) Name() string                               { return m.NameStr }
+func (m *MockProvider) BaseURL() string                            { return m.URL }
+func (m *MockProvider) RoutePrefix() string                        { return fmt.Sprintf("/%s", m.NameStr) }
+func (m *MockProvider) BridgedRoutes() []string                    { return m.Bridged }
+func (m *MockProvider) PassthroughRoutes() []string                { return m.Passthrough }
+func (*MockProvider) AuthHeader() string                           { return "Authorization" }
+func (*MockProvider) InjectAuthHeader(_ *http.Header)              {}
+func (*MockProvider) CircuitBreakerConfig() *config.CircuitBreaker { return nil }
+func (*MockProvider) APIDumpDir() string                           { return "" }
 func (m *MockProvider) CreateInterceptor(w http.ResponseWriter, r *http.Request, tracer trace.Tracer) (intercept.Interceptor, error) {
 	if m.InterceptorFunc != nil {
 		return m.InterceptorFunc(w, r, tracer)

--- a/mcp/proxy_streamable_http.go
+++ b/mcp/proxy_streamable_http.go
@@ -161,7 +161,7 @@ func (p *StreamableHTTPServerProxy) fetchTools(ctx context.Context) (_ map[strin
 	return out, nil
 }
 
-func (p *StreamableHTTPServerProxy) Shutdown(ctx context.Context) error {
+func (p *StreamableHTTPServerProxy) Shutdown(_ context.Context) error {
 	if p.client == nil {
 		return nil
 	}

--- a/provider/anthropic.go
+++ b/provider/anthropic.go
@@ -73,7 +73,7 @@ func NewAnthropic(cfg config.Anthropic, bedrockCfg *config.AWSBedrock) *Anthropi
 	}
 }
 
-func (p *Anthropic) Type() string {
+func (*Anthropic) Type() string {
 	return config.ProviderAnthropic
 }
 
@@ -85,11 +85,11 @@ func (p *Anthropic) RoutePrefix() string {
 	return fmt.Sprintf("/%s", p.Name())
 }
 
-func (p *Anthropic) BridgedRoutes() []string {
+func (*Anthropic) BridgedRoutes() []string {
 	return []string{routeMessages}
 }
 
-func (p *Anthropic) PassthroughRoutes() []string {
+func (*Anthropic) PassthroughRoutes() []string {
 	return []string{
 		"/v1/models",
 		"/v1/models/", // See https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux.
@@ -98,7 +98,7 @@ func (p *Anthropic) PassthroughRoutes() []string {
 	}
 }
 
-func (p *Anthropic) CreateInterceptor(w http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
+func (p *Anthropic) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
 	id := uuid.New()
 	_, span := tracer.Start(r.Context(), "Intercept.CreateInterceptor")
 	defer tracing.EndSpanErr(span, &outErr)
@@ -167,7 +167,7 @@ func (p *Anthropic) BaseURL() string {
 	return p.cfg.BaseURL
 }
 
-func (p *Anthropic) AuthHeader() string {
+func (*Anthropic) AuthHeader() string {
 	return "X-Api-Key"
 }
 

--- a/provider/copilot.go
+++ b/provider/copilot.go
@@ -72,7 +72,7 @@ func NewCopilot(cfg config.Copilot) *Copilot {
 	}
 }
 
-func (p *Copilot) Type() string {
+func (*Copilot) Type() string {
 	return config.ProviderCopilot
 }
 
@@ -88,14 +88,14 @@ func (p *Copilot) RoutePrefix() string {
 	return fmt.Sprintf("/%s", p.Name())
 }
 
-func (p *Copilot) BridgedRoutes() []string {
+func (*Copilot) BridgedRoutes() []string {
 	return []string{
 		routeCopilotChatCompletions,
 		routeCopilotResponses,
 	}
 }
 
-func (p *Copilot) PassthroughRoutes() []string {
+func (*Copilot) PassthroughRoutes() []string {
 	return []string{
 		"/models",
 		"/models/",
@@ -105,7 +105,7 @@ func (p *Copilot) PassthroughRoutes() []string {
 	}
 }
 
-func (p *Copilot) AuthHeader() string {
+func (*Copilot) AuthHeader() string {
 	return "Authorization"
 }
 
@@ -113,7 +113,7 @@ func (p *Copilot) AuthHeader() string {
 // Copilot uses per-user tokens passed in the original Authorization header,
 // rather than a global key configured at the provider level.
 // The original Authorization header flows through untouched from the client.
-func (p *Copilot) InjectAuthHeader(_ *http.Header) {}
+func (*Copilot) InjectAuthHeader(_ *http.Header) {}
 
 func (p *Copilot) CircuitBreakerConfig() *config.CircuitBreaker {
 	return p.circuitBreaker

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -61,7 +61,7 @@ func NewOpenAI(cfg config.OpenAI) *OpenAI {
 	}
 }
 
-func (p *OpenAI) Type() string {
+func (*OpenAI) Type() string {
 	return config.ProviderOpenAI
 }
 
@@ -75,7 +75,7 @@ func (p *OpenAI) RoutePrefix() string {
 	return fmt.Sprintf("/%s/v1", p.Name())
 }
 
-func (p *OpenAI) BridgedRoutes() []string {
+func (*OpenAI) BridgedRoutes() []string {
 	return []string{
 		routeChatCompletions,
 		routeResponses,
@@ -86,7 +86,7 @@ func (p *OpenAI) BridgedRoutes() []string {
 // but must be passed through to the upstream.
 // The /v1/completions legacy API is deprecated and will not be passed through.
 // See https://platform.openai.com/docs/api-reference/completions.
-func (p *OpenAI) PassthroughRoutes() []string {
+func (*OpenAI) PassthroughRoutes() []string {
 	return []string{
 		// See https://pkg.go.dev/net/http#hdr-Trailing_slash_redirection-ServeMux.
 		// but without non trailing slash route requests to `/v1/conversations` are going to catch all
@@ -98,7 +98,7 @@ func (p *OpenAI) PassthroughRoutes() []string {
 	}
 }
 
-func (p *OpenAI) CreateInterceptor(w http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
+func (p *OpenAI) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tracer trace.Tracer) (_ intercept.Interceptor, outErr error) {
 	id := uuid.New()
 
 	_, span := tracer.Start(r.Context(), "Intercept.CreateInterceptor")
@@ -163,7 +163,7 @@ func (p *OpenAI) BaseURL() string {
 	return p.cfg.BaseURL
 }
 
-func (p *OpenAI) AuthHeader() string {
+func (*OpenAI) AuthHeader() string {
 	return "Authorization"
 }
 

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -187,7 +187,7 @@ func (a *AsyncRecorder) WithClient(client string) {
 
 // RecordInterception must NOT be called asynchronously.
 // If an interception cannot be recorded, the whole request should fail.
-func (a *AsyncRecorder) RecordInterception(ctx context.Context, req *InterceptionRecord) error {
+func (a *AsyncRecorder) RecordInterception(_ context.Context, _ *InterceptionRecord) error {
 	panic("RecordInterception must not be called asynchronously")
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -236,6 +236,6 @@ func TestUnreadableBody(t *testing.T) {
 // errReader is an io.Reader that always returns an error.
 type errReader struct{}
 
-func (e *errReader) Read([]byte) (int, error) {
+func (*errReader) Read([]byte) (int, error) {
 	return 0, io.ErrUnexpectedEOF
 }


### PR DESCRIPTION
- receiver-naming (7): standardized receiver names to be consistent within each type (i for interception types)
- unused-receiver (34): omitted unused receiver names on methods that don't reference the receiver (e.g. Streaming(), Type(), AuthHeader(), encodeForStream(), etc.)
- unused-parameter (11): renamed unused ctx to _ in mock recorders, MCP proxy shutdown, and async recorder; renamed unused w to _ in CreateInterceptor; renamed unused ctx to _ in mock MCP tool callback
- unused field (1): removed unused closeOnce sync.Once field from eventstream