### PR TITLE
chore: lint fixes part 5

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -276,7 +276,7 @@ func newInterceptionProcessor(p provider.Provider, cbs *circuitbreaker.ProviderC
 			log.Debug(ctx, "interception ended")
 		}
 
-		asyncRecorder.RecordInterceptionEnded(ctx, &recorder.InterceptionRecordEnded{ID: interceptor.ID().String()})
+		_ = asyncRecorder.RecordInterceptionEnded(ctx, &recorder.InterceptionRecordEnded{ID: interceptor.ID().String()})
 
 		// Ensure all recording have completed before completing request.
 		asyncRecorder.Wait()

--- a/intercept/chatcompletions/base.go
+++ b/intercept/chatcompletions/base.go
@@ -173,7 +173,7 @@ func (i *interceptionBase) unmarshalArgs(in string) (args recorder.ToolArgs) {
 }
 
 // writeUpstreamError marshals and writes a given error.
-func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *errorResponse) {
+func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *chatCompletionResponseError) {
 	if oaiErr == nil {
 		return
 	}
@@ -183,7 +183,7 @@ func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *err
 
 	out, err := json.Marshal(oaiErr)
 	if err != nil {
-		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", slog.F("%+v", oaiErr)))
+		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", oaiErr))
 		// Response has to match expected format.
 		_, _ = w.Write([]byte(`{
 	"error": {
@@ -228,13 +228,13 @@ func calculateActualInputTokenUsage(in openai.CompletionUsage) int64 {
 		in.PromptTokensDetails.CachedTokens /* The aggregated number of text input tokens that has been cached from previous requests. */
 }
 
-func getErrorResponse(err error) *errorResponse {
+func getErrorResponse(err error) *chatCompletionResponseError {
 	var apiErr *openai.Error
 	if !errors.As(err, &apiErr) {
 		return nil
 	}
 
-	return &errorResponse{
+	return &chatCompletionResponseError{
 		ErrorObject: &shared.ErrorObject{
 			Code:    apiErr.Code,
 			Message: apiErr.Message,
@@ -244,15 +244,15 @@ func getErrorResponse(err error) *errorResponse {
 	}
 }
 
-var _ error = &errorResponse{}
+var _ error = &chatCompletionResponseError{}
 
-type errorResponse struct {
+type chatCompletionResponseError struct {
 	ErrorObject *shared.ErrorObject `json:"error"`
 	StatusCode  int                 `json:"-"`
 }
 
-func newErrorResponse(msg error) *errorResponse {
-	return &errorResponse{
+func newErrorResponse(msg error) *chatCompletionResponseError {
+	return &chatCompletionResponseError{
 		ErrorObject: &shared.ErrorObject{
 			Code:    "error",
 			Message: msg.Error(),
@@ -261,7 +261,7 @@ func newErrorResponse(msg error) *errorResponse {
 	}
 }
 
-func (a *errorResponse) Error() string {
+func (a *chatCompletionResponseError) Error() string {
 	if a.ErrorObject == nil {
 		return ""
 	}

--- a/intercept/chatcompletions/base.go
+++ b/intercept/chatcompletions/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -183,7 +184,7 @@ func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *cha
 
 	out, err := json.Marshal(oaiErr)
 	if err != nil {
-		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", oaiErr))
+		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", fmt.Sprintf("%+v", oaiErr)))
 		// Response has to match expected format.
 		_, _ = w.Write([]byte(`{
 	"error": {

--- a/intercept/chatcompletions/base.go
+++ b/intercept/chatcompletions/base.go
@@ -174,7 +174,7 @@ func (i *interceptionBase) unmarshalArgs(in string) (args recorder.ToolArgs) {
 }
 
 // writeUpstreamError marshals and writes a given error.
-func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *chatCompletionResponseError) {
+func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, oaiErr *responseError) {
 	if oaiErr == nil {
 		return
 	}
@@ -229,13 +229,13 @@ func calculateActualInputTokenUsage(in openai.CompletionUsage) int64 {
 		in.PromptTokensDetails.CachedTokens /* The aggregated number of text input tokens that has been cached from previous requests. */
 }
 
-func getErrorResponse(err error) *chatCompletionResponseError {
+func getErrorResponse(err error) *responseError {
 	var apiErr *openai.Error
 	if !errors.As(err, &apiErr) {
 		return nil
 	}
 
-	return &chatCompletionResponseError{
+	return &responseError{
 		ErrorObject: &shared.ErrorObject{
 			Code:    apiErr.Code,
 			Message: apiErr.Message,
@@ -245,15 +245,15 @@ func getErrorResponse(err error) *chatCompletionResponseError {
 	}
 }
 
-var _ error = &chatCompletionResponseError{}
+var _ error = &responseError{}
 
-type chatCompletionResponseError struct {
+type responseError struct {
 	ErrorObject *shared.ErrorObject `json:"error"`
 	StatusCode  int                 `json:"-"`
 }
 
-func newErrorResponse(msg error) *chatCompletionResponseError {
-	return &chatCompletionResponseError{
+func newErrorResponse(msg error) *responseError {
+	return &responseError{
 		ErrorObject: &shared.ErrorObject{
 			Code:    "error",
 			Message: msg.Error(),
@@ -262,7 +262,7 @@ func newErrorResponse(msg error) *chatCompletionResponseError {
 	}
 }
 
-func (a *chatCompletionResponseError) Error() string {
+func (a *responseError) Error() string {
 	if a.ErrorObject == nil {
 		return ""
 	}

--- a/intercept/chatcompletions/streaming.go
+++ b/intercept/chatcompletions/streaming.go
@@ -245,7 +245,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 				logger.Warn(ctx, "openai stream error", slog.Error(streamErr))
 				interceptionErr = oaiErr
 			} else {
-				logger.Warn(ctx, "unknown error", slog.Error(streamErr))
+				logger.Warn(ctx, "unknown stream error encountered", slog.Error(streamErr))
 				// Unfortunately, the OpenAI SDK does not support parsing errors received in the stream
 				// into known types (i.e. [shared.OverloadedError]).
 				// See https://github.com/openai/openai-go/blob/v2.7.0/packages/ssestream/ssestream.go#L171
@@ -254,14 +254,14 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 			}
 		} else if lastErr != nil {
 			// Otherwise check if any logical errors occurred during processing.
-			logger.Warn(ctx, "stream failed", slog.Error(lastErr))
+			logger.Warn(ctx, "stream processing failed", slog.Error(lastErr))
 			interceptionErr = newErrorResponse(xerrors.Errorf("processing error: %w", lastErr))
 		}
 
 		if interceptionErr != nil {
 			payload, err := i.marshalErr(interceptionErr)
 			if err != nil {
-				logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", slog.F("%+v", interceptionErr)))
+				logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", interceptionErr))
 			} else if err := events.Send(streamCtx, payload); err != nil {
 				logger.Warn(ctx, "failed to relay error", slog.Error(err), slog.F("payload", payload))
 			}

--- a/intercept/chatcompletions/streaming.go
+++ b/intercept/chatcompletions/streaming.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -245,7 +246,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 				logger.Warn(ctx, "openai stream error", slog.Error(streamErr))
 				interceptionErr = oaiErr
 			} else {
-				logger.Warn(ctx, "unknown stream error encountered", slog.Error(streamErr))
+				logger.Warn(ctx, "unknown stream error", slog.Error(streamErr))
 				// Unfortunately, the OpenAI SDK does not support parsing errors received in the stream
 				// into known types (i.e. [shared.OverloadedError]).
 				// See https://github.com/openai/openai-go/blob/v2.7.0/packages/ssestream/ssestream.go#L171
@@ -261,7 +262,7 @@ func (i *StreamingInterception) ProcessRequest(w http.ResponseWriter, r *http.Re
 		if interceptionErr != nil {
 			payload, err := i.marshalErr(interceptionErr)
 			if err != nil {
-				logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", interceptionErr))
+				logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", fmt.Sprintf("%+v", interceptionErr)))
 			} else if err := events.Send(streamCtx, payload); err != nil {
 				logger.Warn(ctx, "failed to relay error", slog.Error(err), slog.F("payload", payload))
 			}

--- a/intercept/eventstream/eventstream.go
+++ b/intercept/eventstream/eventstream.go
@@ -132,7 +132,7 @@ func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := flush(w); err != nil {
-			s.logger.Warn(ctx, "failed to flush", slog.Error(err))
+			s.logger.Warn(ctx, "failed to flush event stream", slog.Error(err))
 			return
 		}
 

--- a/intercept/messages/base.go
+++ b/intercept/messages/base.go
@@ -405,7 +405,7 @@ func filterBedrockBetaFlags(headers http.Header, model string) {
 }
 
 // writeUpstreamError marshals and writes a given error.
-func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *ErrorResponse) {
+func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *messagesResponseError) {
 	if antErr == nil {
 		return
 	}
@@ -415,7 +415,7 @@ func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *Err
 
 	out, err := json.Marshal(antErr)
 	if err != nil {
-		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", slog.F("%+v", antErr)))
+		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", antErr))
 		// Response has to match expected format.
 		// See https://docs.claude.com/en/api/errors#error-shapes.
 		_, _ = w.Write([]byte(fmt.Sprintf(`{
@@ -487,7 +487,7 @@ func accumulateUsage(dest, src any) {
 	}
 }
 
-func getErrorResponse(err error) *ErrorResponse {
+func getErrorResponse(err error) *messagesResponseError {
 	var apierr *anthropic.Error
 	if !errors.As(err, &apierr) {
 		return nil
@@ -505,7 +505,7 @@ func getErrorResponse(err error) *ErrorResponse {
 		typ = string(detail.Type)
 	}
 
-	return &ErrorResponse{
+	return &messagesResponseError{
 		ErrorResponse: &anthropic.ErrorResponse{
 			Error: anthropic.ErrorObjectUnion{
 				Message: msg,
@@ -517,16 +517,16 @@ func getErrorResponse(err error) *ErrorResponse {
 	}
 }
 
-var _ error = &ErrorResponse{}
+var _ error = &messagesResponseError{}
 
-type ErrorResponse struct {
+type messagesResponseError struct {
 	*anthropic.ErrorResponse
 
 	StatusCode int `json:"-"`
 }
 
-func newErrorResponse(msg error) *ErrorResponse {
-	return &ErrorResponse{
+func newErrorResponse(msg error) *messagesResponseError {
+	return &messagesResponseError{
 		ErrorResponse: &shared.ErrorResponse{
 			Error: shared.ErrorObjectUnion{
 				Message: msg.Error(),
@@ -536,7 +536,7 @@ func newErrorResponse(msg error) *ErrorResponse {
 	}
 }
 
-func (a *ErrorResponse) Error() string {
+func (a *messagesResponseError) Error() string {
 	if a.ErrorResponse == nil {
 		return ""
 	}

--- a/intercept/messages/base.go
+++ b/intercept/messages/base.go
@@ -415,7 +415,7 @@ func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *mes
 
 	out, err := json.Marshal(antErr)
 	if err != nil {
-		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", antErr))
+		i.logger.Warn(context.Background(), "failed to marshal upstream error", slog.Error(err), slog.F("error_payload", fmt.Sprintf("%+v", antErr)))
 		// Response has to match expected format.
 		// See https://docs.claude.com/en/api/errors#error-shapes.
 		_, _ = w.Write([]byte(fmt.Sprintf(`{

--- a/intercept/messages/base.go
+++ b/intercept/messages/base.go
@@ -405,7 +405,7 @@ func filterBedrockBetaFlags(headers http.Header, model string) {
 }
 
 // writeUpstreamError marshals and writes a given error.
-func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *messagesResponseError) {
+func (i *interceptionBase) writeUpstreamError(w http.ResponseWriter, antErr *responseError) {
 	if antErr == nil {
 		return
 	}
@@ -487,7 +487,7 @@ func accumulateUsage(dest, src any) {
 	}
 }
 
-func getErrorResponse(err error) *messagesResponseError {
+func getErrorResponse(err error) *responseError {
 	var apierr *anthropic.Error
 	if !errors.As(err, &apierr) {
 		return nil
@@ -505,7 +505,7 @@ func getErrorResponse(err error) *messagesResponseError {
 		typ = string(detail.Type)
 	}
 
-	return &messagesResponseError{
+	return &responseError{
 		ErrorResponse: &anthropic.ErrorResponse{
 			Error: anthropic.ErrorObjectUnion{
 				Message: msg,
@@ -517,16 +517,16 @@ func getErrorResponse(err error) *messagesResponseError {
 	}
 }
 
-var _ error = &messagesResponseError{}
+var _ error = &responseError{}
 
-type messagesResponseError struct {
+type responseError struct {
 	*anthropic.ErrorResponse
 
 	StatusCode int `json:"-"`
 }
 
-func newErrorResponse(msg error) *messagesResponseError {
-	return &messagesResponseError{
+func newErrorResponse(msg error) *responseError {
+	return &responseError{
 		ErrorResponse: &shared.ErrorResponse{
 			Error: shared.ErrorObjectUnion{
 				Message: msg.Error(),
@@ -536,7 +536,7 @@ func newErrorResponse(msg error) *messagesResponseError {
 	}
 }
 
-func (a *messagesResponseError) Error() string {
+func (a *responseError) Error() string {
 	if a.ErrorResponse == nil {
 		return ""
 	}

--- a/intercept/messages/streaming.go
+++ b/intercept/messages/streaming.go
@@ -157,7 +157,7 @@ newStream:
 	for {
 		// TODO add outer loop span (https://github.com/coder/aibridge/issues/67)
 		if err := streamCtx.Err(); err != nil {
-			lastErr = xerrors.Errorf("stream exit: %w", err)
+			interceptionErr = xerrors.Errorf("stream exit: %w", err)
 			break
 		}
 
@@ -474,8 +474,8 @@ newStream:
 				MsgID:          message.ID,
 				Prompt:         prompt,
 			})
-			prompt = ""
-			promptFound = false
+			prompt = ""         //nolint:ineffassign // reset to prevent double-recording across newStream iterations
+			promptFound = false //nolint:ineffassign // reset to prevent double-recording across newStream iterations
 		}
 
 		if events.IsStreaming() {
@@ -488,7 +488,7 @@ newStream:
 					logger.Warn(ctx, "anthropic stream error", slog.Error(streamErr))
 					interceptionErr = antErr
 				} else {
-					logger.Warn(ctx, "unknown error", slog.Error(streamErr))
+					logger.Warn(ctx, "unknown stream error encountered", slog.Error(streamErr))
 					// Unfortunately, the Anthropic SDK does not support parsing errors received in the stream
 					// into known types (i.e. [shared.OverloadedError]).
 					// See https://github.com/anthropics/anthropic-sdk-go/blob/v1.12.0/packages/ssestream/ssestream.go#L172-L174
@@ -497,14 +497,14 @@ newStream:
 				}
 			} else if lastErr != nil {
 				// Otherwise check if any logical errors occurred during processing.
-				logger.Warn(ctx, "stream failed", slog.Error(lastErr))
+				logger.Warn(ctx, "stream processing failed", slog.Error(lastErr))
 				interceptionErr = newErrorResponse(xerrors.Errorf("processing error: %w", lastErr))
 			}
 
 			if interceptionErr != nil {
 				payload, err := i.marshal(interceptionErr)
 				if err != nil {
-					logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", slog.F("%+v", interceptionErr)))
+					logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", interceptionErr))
 				} else if err := events.Send(streamCtx, payload); err != nil {
 					logger.Warn(ctx, "failed to relay error", slog.Error(err), slog.F("payload", payload))
 				}

--- a/intercept/messages/streaming.go
+++ b/intercept/messages/streaming.go
@@ -488,7 +488,7 @@ newStream:
 					logger.Warn(ctx, "anthropic stream error", slog.Error(streamErr))
 					interceptionErr = antErr
 				} else {
-					logger.Warn(ctx, "unknown stream error encountered", slog.Error(streamErr))
+					logger.Warn(ctx, "unknown stream error", slog.Error(streamErr))
 					// Unfortunately, the Anthropic SDK does not support parsing errors received in the stream
 					// into known types (i.e. [shared.OverloadedError]).
 					// See https://github.com/anthropics/anthropic-sdk-go/blob/v1.12.0/packages/ssestream/ssestream.go#L172-L174
@@ -504,7 +504,7 @@ newStream:
 			if interceptionErr != nil {
 				payload, err := i.marshal(interceptionErr)
 				if err != nil {
-					logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", interceptionErr))
+					logger.Warn(ctx, "failed to marshal error", slog.Error(err), slog.F("error_payload", fmt.Sprintf("%+v", interceptionErr)))
 				} else if err := events.Send(streamCtx, payload); err != nil {
 					logger.Warn(ctx, "failed to relay error", slog.Error(err), slog.F("payload", payload))
 				}

--- a/internal/integrationtest/circuit_breaker_test.go
+++ b/internal/integrationtest/circuit_breaker_test.go
@@ -149,12 +149,14 @@ func TestCircuitBreaker_FullRecoveryCycle(t *testing.T) {
 				resp := doRequest()
 				assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 			}
+			//nolint:gosec // G115: test constant, no overflow risk
 			assert.Equal(t, int32(cbConfig.FailureThreshold), upstreamCalls.Load())
 
 			// Phase 2: Verify circuit is open
 			// Request should be blocked by circuit breaker (no upstream call)
 			resp := doRequest()
 			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+			//nolint:gosec // G115: test constant, no overflow risk
 			assert.Equal(t, int32(cbConfig.FailureThreshold), upstreamCalls.Load(), "No new upstream call when circuit is open")
 
 			// Verify metrics show circuit is open
@@ -570,11 +572,13 @@ func TestCircuitBreaker_PerModelIsolation(t *testing.T) {
 		resp := doRequest("claude-sonnet-4-20250514")
 		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	}
+	//nolint:gosec // G115: test constant, no overflow risk
 	assert.Equal(t, int32(cbConfig.FailureThreshold), sonnetCalls.Load())
 
 	// Verify sonnet circuit is open
 	resp := doRequest("claude-sonnet-4-20250514")
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "Sonnet circuit should be open")
+	//nolint:gosec // G115: test constant, no overflow risk
 	assert.Equal(t, int32(cbConfig.FailureThreshold), sonnetCalls.Load(), "No new sonnet calls when circuit is open")
 
 	// Verify sonnet metrics show circuit is open

--- a/mcp/proxy_streamable_http.go
+++ b/mcp/proxy_streamable_http.go
@@ -87,7 +87,7 @@ func (p *StreamableHTTPServerProxy) Init(ctx context.Context) (outErr error) {
 		return xerrors.Errorf("MCP version negotiation failed; requested %q, accepts %q, received %q", version, strings.Join(mcp.ValidProtocolVersions, ","), result.ProtocolVersion)
 	}
 
-	p.logger.Debug(ctx, "MCP client initialized", slog.F("name", result.ServerInfo.Name), slog.F("server_version", result.ServerInfo.Version))
+	p.logger.Debug(ctx, "mcp client initialized", slog.F("name", result.ServerInfo.Name), slog.F("server_version", result.ServerInfo.Version))
 
 	tools, err := p.fetchTools(ctx)
 	if err != nil {

--- a/passthrough.go
+++ b/passthrough.go
@@ -44,7 +44,7 @@ func newPassthroughRouter(prov provider.Provider, logger slog.Logger, m *metrics
 		// Append the request path to the upstream base path.
 		reqPath, err := url.JoinPath(upURL.Path, r.URL.Path)
 		if err != nil {
-			logger.Warn(ctx, "failed to join upstream path", slog.Error(err), slog.F("upstreamPath", upURL.Path), slog.F("requestPath", r.URL.Path))
+			logger.Warn(ctx, "failed to join upstream path", slog.Error(err), slog.F("upstream_path", upURL.Path), slog.F("request_path", r.URL.Path))
 			http.Error(w, "failed to join upstream path", http.StatusInternalServerError)
 			span.SetStatus(codes.Error, "failed to join upstream path: "+err.Error())
 			return

--- a/provider/anthropic.go
+++ b/provider/anthropic.go
@@ -106,7 +106,7 @@ func (p *Anthropic) CreateInterceptor(_ http.ResponseWriter, r *http.Request, tr
 	path := strings.TrimPrefix(r.URL.Path, p.RoutePrefix())
 	if path != routeMessages {
 		span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
-		return nil, UnknownRoute
+		return nil, ErrUnknownRoute
 	}
 
 	payload, err := io.ReadAll(r.Body)

--- a/provider/anthropic_test.go
+++ b/provider/anthropic_test.go
@@ -147,7 +147,7 @@ func TestAnthropic_CreateInterceptor(t *testing.T) {
 		assert.Empty(t, receivedHeaders.Get("Authorization"), "client Authorization header must not reach upstream")
 	})
 
-	t.Run("UnknownRoute", func(t *testing.T) {
+	t.Run("ErrUnknownRoute", func(t *testing.T) {
 		t.Parallel()
 
 		body := `{"model": "claude-opus-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "hello"}]}`
@@ -156,7 +156,7 @@ func TestAnthropic_CreateInterceptor(t *testing.T) {
 
 		interceptor, err := provider.CreateInterceptor(w, req, testTracer)
 
-		require.ErrorIs(t, err, UnknownRoute)
+		require.ErrorIs(t, err, ErrUnknownRoute)
 		require.Nil(t, interceptor)
 	})
 }

--- a/provider/copilot.go
+++ b/provider/copilot.go
@@ -183,7 +183,7 @@ func (p *Copilot) CreateInterceptor(_ http.ResponseWriter, r *http.Request, trac
 
 	default:
 		span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
-		return nil, UnknownRoute
+		return nil, ErrUnknownRoute
 	}
 
 	span.SetAttributes(interceptor.TraceAttributes(r)...)

--- a/provider/copilot_test.go
+++ b/provider/copilot_test.go
@@ -301,7 +301,7 @@ func TestCopilot_CreateInterceptor(t *testing.T) {
 		assert.Empty(t, receivedHeaders.Get("X-Api-Key"), "X-Api-Key must not be set upstream")
 	})
 
-	t.Run("UnknownRoute", func(t *testing.T) {
+	t.Run("ErrUnknownRoute", func(t *testing.T) {
 		t.Parallel()
 
 		body := `{"model": "gpt-4.1", "messages": [{"role": "user", "content": "hello"}]}`
@@ -311,7 +311,7 @@ func TestCopilot_CreateInterceptor(t *testing.T) {
 
 		interceptor, err := provider.CreateInterceptor(w, req, testTracer)
 
-		require.ErrorIs(t, err, UnknownRoute)
+		require.ErrorIs(t, err, ErrUnknownRoute)
 		require.Nil(t, interceptor)
 	})
 }

--- a/provider/openai.go
+++ b/provider/openai.go
@@ -153,7 +153,7 @@ func (p *OpenAI) CreateInterceptor(_ http.ResponseWriter, r *http.Request, trace
 
 	default:
 		span.SetStatus(codes.Error, "unknown route: "+r.URL.Path)
-		return nil, UnknownRoute
+		return nil, ErrUnknownRoute
 	}
 	span.SetAttributes(interceptor.TraceAttributes(r)...)
 	return interceptor, nil

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/coder/aibridge/intercept"
 )
 
-var UnknownRoute = xerrors.New("unknown route")
+var ErrUnknownRoute = xerrors.New("unknown route")
 
 // Provider defines routes (bridged and passed through) for given provider.
 // Bridged routes are processed by dedicated interceptors.


### PR DESCRIPTION
- errname (3): UnknownRoute → ErrUnknownRoute; errorResponse → responseError (chatcompletions); ErrorResponse → responseError (messages)
- slog field names (4): "%+v" nested slog.F → direct value; requestPath/upstreamPath → request_path/upstream_path (snake_case)
- slog message length (5): "failed to flush" → "failed to flush event stream"; "stream failed" → "stream processing failed" (2x); "unknown error" → "unknown stream error" (2x)
- slog message case (1): "MCP client initialized" → "mcp client initialized"
- gosec G115 (4): added nolint:gosec for test constant uint32→int32 conversions
- errcheck (1): explicitly discarded RecordInterceptionEnded return value
- ineffassign (3): propagated streamCtx.Err() to interceptionErr instead of dead lastErr; added nolint:ineffassign for intentional prompt/promptFound resets