### PR TITLE
ci: validate example app compiles on each PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           config: .github/workflows/typos.toml
 
+      - name: Build example app
+        run: make build-example
+
       - name: Lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ lint/shellcheck:
 	fi
 .PHONY: lint/shellcheck
 
+build-example:
+	cd example && go build -o /dev/null .
+.PHONY: build-example
+
 test:
 	go test -count=1 ./...
 


### PR DESCRIPTION
Fixes https://github.com/coder/aibridge/issues/100

Add build-example Makefile target and CI step to ensure the example application always compiles, catching regressions early.

@pawbana this is simple enough to incorporate in your merging campaign or drop it.