### PR TITLE
fix: ignore conn errors in SSE writer

### DIFF
--- a/internal/integrationtest/mockupstream.go
+++ b/internal/integrationtest/mockupstream.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/coder/aibridge/fixtures"
+	"github.com/coder/aibridge/intercept/eventstream"
 )
 
 // upstreamResponse defines a single response that mockUpstream will replay
@@ -222,6 +223,9 @@ func (ms *mockUpstream) writeSSE(w http.ResponseWriter, data []byte) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		_, err := fmt.Fprintf(w, "%s\n", scanner.Text())
+		if eventstream.IsConnError(err) {
+			return // client disconnected, stop writing
+		}
 		require.NoError(ms.t, err)
 		flusher.Flush()
 	}


### PR DESCRIPTION
When aibridge finishes the inner loop and ProcessRequest returns, the deferred context cancel fires. The mock upstream may still be writing SSE data at that point and gets a broken pipe. This is expected, use `eventstream.IsConnError` to detect it and stop writing instead of failing the test.

Spotted in: https://github.com/coder/aibridge/actions/runs/24564893487/job/71822444524

```
--- FAIL: TestInjectedToolsTrace (0.00s)
    --- FAIL: TestInjectedToolsTrace/anthr_streaming (0.01s)
        t.go:111: 2026-04-17 12:25:34.330 [debu]  mcp client initialized  trace=05962868f63f9ab9a5cd2da4ca72f92a  span=e6598f31df9a1f49  name="Mock coder MCP server"  server_version=1.0.0
        t.go:111: 2026-04-17 12:25:34.331 [debu]  interception started  trace=2106871eb2c2b71133a31486e2121924  span=5113920ce52aa0fd  route=/v1/messages  provider=anthropic  interception_id=4ce0eadd-d53c-4a64-88be-18ff19d90aee  user_agent=Go-http-client/1.1  streaming=true  credential_kind=centralized  credential_hint=a...y  credential_length=7
        t.go:111: 2026-04-17 12:25:34.331 [debu]  streaming: using api key auth  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  api_key_hint=a...y
        t.go:111: 2026-04-17 12:25:34.332 [debu]  streaming.sse-sender: stream initiated  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  model=claude-sonnet-4-20250514
        t.go:111: 2026-04-17 12:25:34.333 [debu]  injected tool invoked  trace=2106871eb2c2b71133a31486e2121924  span=272b9be33b3adfb8  name=coder_list_workspaces  server=coder  input="{\"owner\":\"admin\"}"  duration_sec=0.000480635  error=<nil>
        t.go:111: 2026-04-17 12:25:34.334 [debu]  streaming.sse-sender: request context canceled  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  model=claude-sonnet-4-20250514  error="context canceled"
        t.go:111: 2026-04-17 12:25:34.334 [debu]  streaming: stream terminated  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  model=claude-sonnet-4-20250514  error="context canceled"
        t.go:111: 2026-04-17 12:25:34.334 [debu]  streaming.sse-sender: shutdown initiated  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  model=claude-sonnet-4-20250514  outstanding_events=0
        t.go:111: 2026-04-17 12:25:34.334 [warn]  streaming: event stream shutdown  trace=2106871eb2c2b71133a31486e2121924  span=63f4f77342e0d1c9  model=claude-sonnet-4-20250514 ...
            error= shutdown ended prematurely with 0 outstanding events:
                       github.com/coder/aibridge/intercept/eventstream.(*EventStream).Shutdown
                           /home/runner/work/aibridge/aibridge/intercept/eventstream/eventstream.go:210
                     - context canceled
        t.go:111: 2026-04-17 12:25:34.334 [debu]  interception ended  trace=2106871eb2c2b71133a31486e2121924  span=5113920ce52aa0fd  route=/v1/messages  provider=anthropic  interception_id=4ce0eadd-d53c-4a64-88be-18ff19d90aee  user_agent=Go-http-client/1.1  streaming=true  credential_kind=centralized  credential_hint=a...y  credential_length=7
        mockupstream.go:174: 
            	Error Trace:	/home/runner/work/aibridge/aibridge/internal/integrationtest/mockupstream.go:225
            	            				/home/runner/work/aibridge/aibridge/internal/integrationtest/mockupstream.go:174
            	            				/opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:2322
            	            				/opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:3340
            	            				/opt/hostedtoolcache/go/1.25.6/x64/src/net/http/server.go:2109
            	            				/opt/hostedtoolcache/go/1.25.6/x64/src/runtime/asm_amd64.s:1693
            	Error:      	Received unexpected error:
            	            	write tcp 127.0.0.1:36743->127.0.0.1:43848: write: broken pipe
            	Test:       	TestInjectedToolsTrace/anthr_streaming
FAIL
FAIL	github.com/coder/aibridge/internal/integrationtest	3.268s

```