### PR TITLE
fix: remove SessionToken from Bedrock config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,6 @@ type Anthropic struct {
 type AWSBedrock struct {
 	Region                     string
 	AccessKey, AccessKeySecret string
-	SessionToken               string
 	Model, SmallFastModel      string
 	// If set, requests will be sent to this URL instead of the default AWS Bedrock endpoint
 	// (https://bedrock-runtime.{region}.amazonaws.com).

--- a/intercept/messages/base.go
+++ b/intercept/messages/base.go
@@ -270,9 +270,9 @@ func (i *interceptionBase) withBody() option.RequestOption {
 // withAWSBedrockOptions returns request options for authenticating with AWS Bedrock.
 //
 // When both AccessKey and AccessKeySecret are set in the aibridge config, they are
-// used directly as static credentials (with an optional SessionToken for temporary credentials).
-// Otherwise, the AWS SDK default credential chain resolves credentials (environment variables,
-// shared config/credentials files, IAM roles, IRSA, SSO, IMDS, etc.).
+// used directly as static credentials. Otherwise, the AWS SDK default credential chain
+// resolves credentials (environment variables, shared config/credentials files, IAM
+// roles, IRSA, SSO, IMDS, etc.).
 func (*interceptionBase) withAWSBedrockOptions(ctx context.Context, cfg *aibconfig.AWSBedrock) ([]option.RequestOption, error) {
 	if cfg == nil {
 		return nil, xerrors.New("nil config given")
@@ -299,7 +299,7 @@ func (*interceptionBase) withAWSBedrockOptions(ctx context.Context, cfg *aibconf
 			credentials.NewStaticCredentialsProvider(
 				cfg.AccessKey,
 				cfg.AccessKeySecret,
-				cfg.SessionToken, // optional
+				"",
 			),
 		))
 	// Only one set: misconfiguration.

--- a/intercept/messages/base_test.go
+++ b/intercept/messages/base_test.go
@@ -120,17 +120,6 @@ func TestAWSBedrockValidation(t *testing.T) {
 				SmallFastModel:  "test-small-model",
 			},
 		},
-		{
-			name: "static credentials with session token",
-			cfg: &config.AWSBedrock{
-				Region:          "us-east-1",
-				AccessKey:       "test-key",
-				AccessKeySecret: "test-secret",
-				SessionToken:    "test-session-token",
-				Model:           "test-model",
-				SmallFastModel:  "test-small-model",
-			},
-		},
 		// Invalid cases.
 		{
 			name: "missing region & base url",


### PR DESCRIPTION
## Description

Removes `SessionToken` from the `AWSBedrock` config. The field was introduced in #265 but shouldn't have been exposed. AWS temporary credentials are short-lived and aibridge reads config once at startup with no refresh mechanism. A user configuring a session token via aibridge would have a deployment that silently breaks when credentials expire.

Users with temporary credentials should rely on the AWS SDK default credential chain instead: credential sources cannot be mixed, so all three values (access key, secret, session token) must come from outside aibridge (env vars, shared config files, IAM roles, etc.). The SDK handles credential refresh automatically.

Related to: #265 
Related to: https://github.com/coder/coder/pull/24346